### PR TITLE
Cleans up procedure tests and fixes unclean connection teardowns

### DIFF
--- a/src/test/java/com/teragrep/cfe18/procedureTests/DBUnitbase.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/DBUnitbase.java
@@ -48,13 +48,17 @@ package com.teragrep.cfe18.procedureTests;
 import org.dbunit.DBTestCase;
 import org.dbunit.PropertiesBasedJdbcDatabaseTester;
 import org.dbunit.database.DatabaseConfig;
+import org.dbunit.database.DatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
 import org.dbunit.ext.mysql.MySqlMetadataHandler;
 import org.dbunit.operation.DatabaseOperation;
+import org.junit.jupiter.api.Assertions;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
 
 
 public abstract class DBUnitbase extends DBTestCase {
@@ -63,7 +67,8 @@ public abstract class DBUnitbase extends DBTestCase {
     protected String DBUNIT_CONNECTION_URL = System.getProperty("tests.dbunit.connection.url");
     protected String DBUNIT_USERNAME = System.getProperty("tests.dbunit.username");
     protected String DBUNIT_PASSWORD = System.getProperty("tests.dbunit.password");
-
+    Connection conn;
+    DatabaseConnection databaseConnection;
 
     public DBUnitbase(String name) {
         super(name);
@@ -75,10 +80,10 @@ public abstract class DBUnitbase extends DBTestCase {
 
 
     protected void setUpDatabaseConfig(DatabaseConfig config) {
-        super.setUpDatabaseConfig(config);
         config.setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER, new MySqlMetadataHandler());
         config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, true);
         config.setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, true);
+        super.setUpDatabaseConfig(config);
     }
 
     @Override
@@ -88,14 +93,21 @@ public abstract class DBUnitbase extends DBTestCase {
 
     @Override
     protected DatabaseOperation getSetUpOperation() {
+        Assertions.assertAll(() -> {
+            conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
+            databaseConnection = (DatabaseConnection) getConnection();
+        });
         return DatabaseOperation.CLEAN_INSERT;
 
     }
 
     @Override
     protected DatabaseOperation getTearDownOperation() {
+        Assertions.assertAll(() -> {
+            conn.close();
+            databaseConnection.close();
+
+        });
         return DatabaseOperation.DELETE_ALL;
-
     }
-
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureCaptureGroupTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureCaptureGroupTest.java
@@ -54,7 +54,9 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -83,9 +85,6 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
     accordingly.
      */
     public void testProcedureAddCaptureGroupSuccess() throws Exception {
-
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCaptureGroup/procedureCaptureGroupTestDataExpectedData1.xml"));
         ITable expectedTable1 = expectedDataSet.getTable("cfe_18.capture_def_group_x_capture_def");
         ITable expectedTable2 = expectedDataSet.getTable("cfe_18.capture_def_group");
@@ -95,8 +94,8 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
         stmnt.setInt(2, 1);
         stmnt.execute();
 
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_group");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_group");
 
         Assertion.assertEqualsIgnoreCols(expectedTable2, actualTable2, new String[]{"id"});
         Assertion.assertEqualsIgnoreCols(expectedTable1, actualTable1, new String[]{"id", "capture_def_group_id"});
@@ -107,8 +106,6 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
     This test is for when adding a capture_group with the same name does not create another group but rather uses the existing one with new capture_definition
      */
     public void testNoDuplicateCaptureGroup() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCaptureGroup/procedureCaptureGroupTestDataExpectedData2.xml"));
         ITable expectedTable1 = expectedDataSet.getTable("cfe_18.capture_def_group_x_capture_def");
         ITable expectedTable2 = expectedDataSet.getTable("cfe_18.capture_def_group");
@@ -118,8 +115,8 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
         stmnt.setInt(2, 2);
         stmnt.execute();
 
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_group");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_group");
 
         Assertion.assertEqualsIgnoreCols(expectedTable2, actualTable2, new String[]{"id"});
         Assertion.assertEqualsIgnoreCols(expectedTable1, actualTable1, new String[]{"id", "capture_def_group_id"});
@@ -130,8 +127,6 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
     capture_group retrieval needs to be checked aswell. It is important that the values are gathered
      */
     public void testRetrieveCaptureGroup() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         List<Integer> actualList = new ArrayList<>();
         CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.retrieve_capture_group_details(?)}");
         stmnt.setString(1, "capturegroup1");
@@ -153,17 +148,11 @@ public class ProcedureCaptureGroupTest extends DBUnitbase {
     If the capture_group does not exist. This needs to be tested.
      */
     public void testCaptureGroupIsMissing() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.retrieve_capture_group_details(?)}");
             stmnt.setString(1, "groupThatDontExist");
             stmnt.execute();
         });
-
         Assertions.assertEquals("45000", state.getSQLState());
-
     }
-
-
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureCaptureMetaFileTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureCaptureMetaFileTest.java
@@ -54,10 +54,9 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 
 /*
@@ -80,9 +79,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     In this example Tag and Tag_path are tested aswell that they are the same when inserting.
      */
     public void testProcedureAddCaptureSuccess() throws Exception {
-
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCapture/procedureCaptureExpectedTestData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.capture_definition");
 
@@ -100,7 +96,7 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
         stmnt.setString(11, "usesregex");
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.capture_definition");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_definition");
 
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, new String[]{"capture_type_id", "id", "tag_id"});
 
@@ -111,7 +107,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     Aim is to trigger sql state signal where this is not allowed
      */
     public void testProcedureCaptureTagMismatch() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{call cfe_18.add_new_capture_file(?,?,?,?,?,?,?,?,?,?,?)}");
             stmnt.setString(1, "632db722-tag.tag");
@@ -134,7 +129,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
      Test for checking capture insertion without tag. Tag path is suppose to create the new tag.
     */
     public void testProcedureCaptureTagCreate() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCapture/procedureCaptureExpectedTestData2.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.tags");
 
@@ -151,7 +145,7 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
         stmnt.setString(10, "PathToCapture");
         stmnt.setString(11, "usesregex");
         stmnt.execute();
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.tags");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.tags");
 
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, new String[]{"id"});
     }
@@ -162,7 +156,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     This test should accept the creation of new capture even tho there is no tag_path.
 */
     public void testProcedureCaptureTagPathNull() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCapture/procedureCaptureExpectedTestData3.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.capture_definition");
         ITable expectedTable1 = expectedDataSet.getTable("cfe_18.tags");
@@ -182,9 +175,10 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
         stmnt.setString(11, "usesregex");
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.capture_definition");
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_18.tags");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_18.capture_meta_file");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_definition");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_18.tags");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_meta_file");
+
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, new String[]{"capture_type_id", "id", "tag_id"});
         Assertion.assertEqualsIgnoreCols(expectedTable1, actualTable1, new String[]{"id"});
         Assertion.assertEqualsIgnoreCols(expectedTable2, actualTable2, new String[]{"id"});
@@ -196,7 +190,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
 */
 
     public void testProcedureCaptureMissingProcessingType() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{call cfe_18.add_new_capture_file(?,?,?,?,?,?,?,?,?,?,?)}");
             stmnt.setString(1, "632db722-tag.tag");
@@ -220,7 +213,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     */
 
     public void testProcedureCaptureFaultyProcessingType() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{call cfe_18.add_new_capture_file(?,?,?,?,?,?,?,?,?,?,?)}");
             stmnt.setString(1, "632db722-tag.tag");
@@ -245,7 +237,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
 
  */
     public void testProcedureCaptureDuplicateAvoid() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureCapture/procedureCaptureExpectedTestData4.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.tags");
         ITable expectedTable1 = expectedDataSet.getTable("cfe_18.retentionTime");
@@ -272,16 +263,17 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
         stmnt.setString(11, "usesregex");
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.tags");
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_18.retentionTime");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_18.category");
-        ITable actualTable3 = getConnection().createQueryTable("result", "select * from cfe_18.application");
-        ITable actualTable4 = getConnection().createQueryTable("result", "select * from cfe_18.captureIndex");
-        ITable actualTable5 = getConnection().createQueryTable("result", "select * from cfe_18.captureSourcetype");
-        ITable actualTable6 = getConnection().createQueryTable("result", "select * from flow.L7");
-        ITable actualTable7 = getConnection().createQueryTable("result", "select * from flow.flows");
-        ITable actualTable8 = getConnection().createQueryTable("result", "select * from cfe_18.capture_meta_file");
-        ITable actualTable9 = getConnection().createQueryTable("result", "select * from cfe_18.processing_type");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.tags");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_18.retentionTime");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_18.category");
+        ITable actualTable3 = databaseConnection.createQueryTable("result", "select * from cfe_18.application");
+        ITable actualTable4 = databaseConnection.createQueryTable("result", "select * from cfe_18.captureIndex");
+        ITable actualTable5 = databaseConnection.createQueryTable("result", "select * from cfe_18.captureSourcetype");
+        ITable actualTable6 = databaseConnection.createQueryTable("result", "select * from flow.L7");
+        ITable actualTable7 = databaseConnection.createQueryTable("result", "select * from flow.flows");
+        ITable actualTable8 = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_meta_file");
+        ITable actualTable9 = databaseConnection.createQueryTable("result", "select * from cfe_18.processing_type");
+
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, new String[]{"id"});
         Assertion.assertEqualsIgnoreCols(expectedTable1, actualTable1, new String[]{"id"});
         Assertion.assertEqualsIgnoreCols(expectedTable2, actualTable2, new String[]{"id"});
@@ -298,47 +290,28 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     This test confirms that data is retrieved accurately from capture_definition via procedure.
      */
     public void testProcedureCaptureGetById() throws Exception {
-
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-        List<Integer> actualList = new ArrayList<>();
         CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.retrieve_capture_by_id(?)}");
         stmnt.setString(1, "1");
         ResultSet rs = stmnt.executeQuery();
-        while (rs.next()) {
-            actualList.add(rs.getInt("id"));
-            String tag = rs.getString("tag");
-            String app = rs.getString("app");
-            String captureIndex = rs.getString("captureIndex");
-            String retention_time = rs.getString("retention_time");
-            String source_type = rs.getString("source_type");
-            String category = rs.getString("category");
-            String rule_name = rs.getString("rule_name");
-            String flow = rs.getString("flow");
-            String protocol = rs.getString("protocol");
-            String capture_path = rs.getString("capture_path");
-            String tag_path = rs.getString("tag_path");
-            Assertions.assertEquals("tag1", tag);
-            Assertions.assertEquals("app1", app);
-            Assertions.assertEquals("index1", captureIndex);
-            Assertions.assertEquals("P30D", retention_time);
-            Assertions.assertEquals("sourcetype1", source_type);
-            Assertions.assertEquals("audit", category);
-            Assertions.assertEquals("usesregex", rule_name);
-            Assertions.assertEquals("flow1", flow);
-            Assertions.assertEquals("prot1", protocol);
-            Assertions.assertEquals("capPathRegex", capture_path);
-            Assertions.assertEquals("tagPathRegex", tag_path);
-        }
-        // Expecting to get only one record with ID of 1
-        Assertions.assertEquals(Arrays.asList(1), actualList);
+        rs.next(); // Needs to forward to first
+        Assertions.assertEquals(1, rs.getInt("id"));
+        Assertions.assertEquals("tag1", rs.getString("tag"));
+        Assertions.assertEquals("app1", rs.getString("app"));
+        Assertions.assertEquals("index1", rs.getString("captureIndex"));
+        Assertions.assertEquals("P30D", rs.getString("retention_time"));
+        Assertions.assertEquals("sourcetype1", rs.getString("source_type"));
+        Assertions.assertEquals("audit", rs.getString("category"));
+        Assertions.assertEquals("usesregex", rs.getString("rule_name"));
+        Assertions.assertEquals("flow1", rs.getString("flow"));
+        Assertions.assertEquals("prot1", rs.getString("protocol"));
+        Assertions.assertEquals("capPathRegex", rs.getString("capture_path"));
+        Assertions.assertEquals("tagPathRegex", rs.getString("tag_path"));
     }
 
     /*
     This test is for checking that capture can not be inserted if L7_id is faulty or missing
      */
     public void testMissingL7() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{call cfe_18.add_new_capture_file(?,?,?,?,?,?,?,?,?,?,?)}");
             stmnt.setString(1, "632db722-tag.tag");
@@ -362,8 +335,6 @@ public class ProcedureCaptureMetaFileTest extends DBUnitbase {
     This test is for checking that capture can not be inserted if flow_id is faulty or missing
      */
     public void testMissingFlow() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{call cfe_18.add_new_capture_file(?,?,?,?,?,?,?,?,?,?,?)}");
             stmnt.setString(1, "632db722-tag.tag");

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureHostMetaFileTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureHostMetaFileTest.java
@@ -54,7 +54,9 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -75,9 +77,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     Testi millä katsotaan IP n lisäys host_metaan mukaan.
      */
     public void testProcedureAddIpToHostMeta() throws Exception {
-
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureHostMeta/procedureHostMetaTestDataExpected1.xml"));
         ITable expectedTable1 = expectedDataSet.getTable("cfe_03.ip_addresses");
         ITable expectedTable2 = expectedDataSet.getTable("cfe_03.host_meta_x_ip");
@@ -87,8 +86,8 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
         stmnt.setString(2, "ipaddress1");
         stmnt.execute();
 
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_03.ip_addresses");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_03.host_meta_x_ip");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_03.ip_addresses");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_03.host_meta_x_ip");
 
         Assertion.assertEquals(expectedTable1, actualTable1);
         Assertion.assertEquals(expectedTable2, actualTable2);
@@ -100,8 +99,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
      palauttaa 42000 error
      */
     public void testHostMetaValidityOnIp() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_03.add_ip_address(?,?)}");
             stmnt.setInt(1, 1000);
@@ -116,8 +113,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     palauttaa 42000 error
     */
     public void testHostMetaValidityOnInterface() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_03.add_interface(?,?)}");
             stmnt.setInt(2, 1000);
@@ -131,8 +126,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     Testi millä katsotaan interfacen lisäys host metan mukaan.
     */
     public void testProcedureAddInterfaceToHostMeta() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureHostMeta/procedureHostMetaTestDataExpected2.xml"));
         ITable expectedTable1 = expectedDataSet.getTable("cfe_03.interfaces");
         ITable expectedTable2 = expectedDataSet.getTable("cfe_03.host_meta_x_interface");
@@ -142,8 +135,8 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
         stmnt.setInt(2, 1);
         stmnt.execute();
 
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from cfe_03.interfaces");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_03.host_meta_x_interface");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from cfe_03.interfaces");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_03.host_meta_x_interface");
 
         Assertion.assertEquals(expectedTable1, actualTable1);
         Assertion.assertEquals(expectedTable2, actualTable2);
@@ -154,8 +147,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     Testi millä katsotaan onnistuuko host_metan lisääminen hostiin.
  */
     public void testHostMetaWithHost() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureHostMeta/procedureHostMetaTestDataExpected3.xml"));
         ITable expectedTable2 = expectedDataSet.getTable("cfe_03.host_meta");
         // käytetään aiempia arvoja mitä on jo testidatassa. Halutaan vain nähdä syntyykö uusi host meta hostille jolla ei ole host metaa vielä.
@@ -168,7 +159,7 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
         stmnt.setString(6, "release_version2");
         stmnt.execute();
 
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from cfe_03.host_meta");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from cfe_03.host_meta");
 
         Assertion.assertEquals(expectedTable2, actualTable2);
 
@@ -180,8 +171,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     palauttaa 42000 jos hostia ei ole olemassa
      */
     public void testHostExistenceOnHostMeta() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_03.add_host_meta_data(?,?,?,?,?,?)}");
             stmnt.setString(1, "arch1");
@@ -200,8 +189,6 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     Testi millä katsotaan onnistuuko host metan palautus oikeilla arvoilla.
     */
     public void testHostMetaRetrieve() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         List<String> IpList = new ArrayList<>();
         List<String> InterfaceList = new ArrayList<>();
         CallableStatement stmnt = conn.prepareCall("{CALL cfe_03.retrieve_host_meta(?)}");
@@ -210,19 +197,12 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
         while (rs.next()) {
             IpList.add(rs.getString("ip_address"));
             InterfaceList.add(rs.getString("interface"));
-            int host_meta_id = rs.getInt("host_meta_id");
-            String arch = rs.getString("arch");
-            String release_version = rs.getString("release_version");
-            String flavor = rs.getString("flavor");
-            String os = rs.getString("os");
-            String hostname = rs.getString("hostname");
-            Assertions.assertEquals(host_meta_id, 1);
-            Assertions.assertEquals(arch, "arch1");
-            Assertions.assertEquals(release_version, "release_version1");
-            Assertions.assertEquals(flavor, "flavor1");
-            Assertions.assertEquals(os, "Linux1");
-            Assertions.assertEquals(hostname, "host1");
-
+            Assertions.assertEquals(1, rs.getInt("host_meta_id"));
+            Assertions.assertEquals("arch1", rs.getString("arch"));
+            Assertions.assertEquals("release_version1", rs.getString("release_version"));
+            Assertions.assertEquals("flavor1", rs.getString("flavor"));
+            Assertions.assertEquals("Linux1", rs.getString("os"));
+            Assertions.assertEquals("host1", rs.getString("hostname"));
         }
         Assertions.assertEquals(Arrays.asList("ip1", "ip2", "ip3", "ip1", "ip2", "ip3"), IpList);
         Assertions.assertEquals(Arrays.asList("ens192", "ens192", "ens192", "ens256", "ens256", "ens256"), InterfaceList);
@@ -232,40 +212,18 @@ public class ProcedureHostMetaFileTest extends DBUnitbase {
     Testi millä tarkastetaan cfe hostin palautus missä host_meta_id tulee mukana. Testidatan vuoksi hostin testi täälä.
 */
     public void testProcedureRetrieveCfeHost() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         CallableStatement stmnt = conn.prepareCall("{CALL cfe_00.retrieve_host_details(?)}");
         stmnt.setInt(1, 2);
         ResultSet rs = stmnt.executeQuery();
-        int host_id = 0;
-        String md5 = null;
-        String fqhost = null;
-        String host_type = null;
-        int hub_id = 0;
-        String hostname = null;
-        int host_meta_id = 0;
-        String hub_fq = null;
-        // roll through the result
-        while (rs.next()) {
-            host_id = rs.getInt("host_id");
-            md5 = rs.getString("host_md5");
-            fqhost = rs.getString("host_fq");
-            host_type = rs.getString("host_type");
-            hub_id = rs.getInt("hub_id");
-            hostname = rs.getString("host_name");
-            host_meta_id = rs.getInt("host_meta_id");
-            hub_fq = rs.getString("hub_fq");
-
-        }
-        Assertions.assertEquals(host_id, 2); // host_id
-        Assertions.assertEquals(md5, "12322"); // md5
-        Assertions.assertEquals(fqhost, "2"); // fqhost
-        Assertions.assertEquals(host_type, "cfe"); // host_type
-        Assertions.assertEquals(hub_id, 1); // hub_id
-        Assertions.assertEquals(hostname, "host1"); // hostname
-        Assertions.assertEquals(host_meta_id, 1); // host_meta_id
-        Assertions.assertEquals(hub_fq, "1"); // hub_fq
-
+        rs.next();
+        Assertions.assertEquals(2, rs.getInt("host_id")); // host_id
+        Assertions.assertEquals("12322", rs.getString("host_md5")); // md5
+        Assertions.assertEquals("2", rs.getString("host_fq")); // fqhost
+        Assertions.assertEquals("cfe", rs.getString("host_type")); // host_type
+        Assertions.assertEquals(1, rs.getInt("hub_id")); // hub_id
+        Assertions.assertEquals("host1", rs.getString("host_name")); // hostname
+        Assertions.assertEquals(1, rs.getInt("host_meta_id")); // host_meta_id
+        Assertions.assertEquals("1", rs.getString("hub_fq")); // hub_fq
     }
 }
 

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureProcessingTypeTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureProcessingTypeTest.java
@@ -54,7 +54,9 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 public class ProcedureProcessingTypeTest extends DBUnitbase {
     public ProcedureProcessingTypeTest(String name) {
@@ -71,8 +73,6 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
     This test checks that procedure is in place and accepts insertion with new and correct values.
      */
     public void testProcessingTypeAcceptInsert() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         // Gets the expected dataset
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureProcessingType/procedureProcessingTypeExpectedTestData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.processing_type");
@@ -86,7 +86,7 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
         stmnt.setString(5, "TestRegex2");
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.processing_type");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.processing_type");
 
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, new String[]{"ruleset_id", "template_id"});
 
@@ -98,8 +98,6 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
      next 4 tests are for checking if one of the values inserted was null
      */
     public void testProcessingTypeNullRegex() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.create_data_for_processing_type(?,?,?,?,?)}");
             stmnt.setString(1, "template1");
@@ -113,8 +111,6 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
     }
 
     public void testProcessingTypeNullNewline() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.create_data_for_processing_type(?,?,?,?,?)}");
             stmnt.setString(1, "template1");
@@ -128,8 +124,6 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
     }
 
     public void testProcessingTypeNullRuleset() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.create_data_for_processing_type(?,?,?,?,?)}");
             stmnt.setString(1, "template1");
@@ -143,8 +137,6 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
     }
 
     public void testProcessingTypeNullTemplate() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.create_data_for_processing_type(?,?,?,?,?)}");
             stmnt.setString(1, null);
@@ -162,28 +154,14 @@ public class ProcedureProcessingTypeTest extends DBUnitbase {
     Checks if the values inserted from XML correspond to the values fetch via procedure call.
      */
     public void testProcessingTypeRetrieveByName() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         CallableStatement stmnt = conn.prepareCall("{CALL cfe_18.retrieve_processing_type_by_name(?)}");
         stmnt.setString(1, "name1");
         ResultSet rs = stmnt.executeQuery();
-        String ruleset = null;
-        String template = null;
-        String name = null;
-        String inputtype = null;
-        String inputvalue = null;
-        while (rs.next()) {
-            ruleset = rs.getString("ruleset");
-            template = rs.getString("template");
-            name = rs.getString("name");
-            inputtype = rs.getString("inputtype");
-            inputvalue = rs.getString("inputvalue");
-
-        }
-        Assertions.assertEquals("RulesAreMadeToBeBroken", ruleset);
-        Assertions.assertEquals("TemplateForBaking", template);
-        Assertions.assertEquals("name1", name);
-        Assertions.assertEquals("regex", inputtype);
-        Assertions.assertEquals("YourNormalRegex", inputvalue);
+        rs.next();
+        Assertions.assertEquals("RulesAreMadeToBeBroken", rs.getString("ruleset"));
+        Assertions.assertEquals("TemplateForBaking", rs.getString("template"));
+        Assertions.assertEquals("name1", rs.getString("name"));
+        Assertions.assertEquals("regex", rs.getString("inputtype"));
+        Assertions.assertEquals("YourNormalRegex", rs.getString("inputvalue"));
     }
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureSinkTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureSinkTest.java
@@ -54,7 +54,8 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
 
 public class ProcedureSinkTest extends DBUnitbase {
 
@@ -71,8 +72,6 @@ public class ProcedureSinkTest extends DBUnitbase {
     This test checks that completely new sink can be added with new protocol and flow.
      */
     public void testSinkAccept() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureSink/procedureSinkExpectedData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("flow.capture_sink");
         ITable expectedTable1 = expectedDataSet.getTable("flow.L7");
@@ -85,9 +84,9 @@ public class ProcedureSinkTest extends DBUnitbase {
         stmnt.setString(4, "flow2");
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from flow.capture_sink");
-        ITable actualTable1 = getConnection().createQueryTable("result", "select * from flow.L7");
-        ITable actualTable2 = getConnection().createQueryTable("result", "select * from flow.flows");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from flow.capture_sink");
+        ITable actualTable1 = databaseConnection.createQueryTable("result", "select * from flow.L7");
+        ITable actualTable2 = databaseConnection.createQueryTable("result", "select * from flow.flows");
 
         Assertion.assertEquals(expectedTable, actualTable);
         Assertion.assertEquals(expectedTable1, actualTable1);
@@ -101,24 +100,13 @@ public class ProcedureSinkTest extends DBUnitbase {
     Goal is to receive correct values from retrieve_sink_by_id procedure
      */
     public void testSinkRetrieveById() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         CallableStatement stmnt = conn.prepareCall("{CALL flow.retrieve_sink_by_id(?)}");
         stmnt.setString(1, "1");
         ResultSet rs = stmnt.executeQuery();
-        String ip = null;
-        String port = null;
-        String protocol = null;
-        String flow = null;
-        while (rs.next()) {
-            ip = rs.getString("ip");
-            port = rs.getString("port");
-            protocol = rs.getString("protocol");
-            flow = rs.getString("flow");
-        }
-        Assertions.assertEquals("ip11", ip);
-        Assertions.assertEquals("601", port);
-        Assertions.assertEquals("prot1", protocol);
-        Assertions.assertEquals("flow2", flow);
+        rs.next();
+        Assertions.assertEquals("ip11", rs.getString("ip"));
+        Assertions.assertEquals("601", rs.getString("port"));
+        Assertions.assertEquals("prot1", rs.getString("protocol"));
+        Assertions.assertEquals("flow2", rs.getString("flow"));
     }
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
@@ -56,8 +56,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -78,8 +76,6 @@ public class ProcedureStorageTest extends DBUnitbase {
     -Throws 42000 when not existing
     */
     public void testStorageFlowExistence() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL flow.add_storage(?,?)}");
             stmnt.setString(1, "FlowThatDontExist");
@@ -98,7 +94,6 @@ public class ProcedureStorageTest extends DBUnitbase {
   */
 
     public void testStorageFlowAccept() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureStorage/procedureStorageExpectedTestData1.xml"));
 
         ITable expectedTable = expectedDataSet.getTable("flow.flow_targets");
@@ -108,7 +103,7 @@ public class ProcedureStorageTest extends DBUnitbase {
         stmnt.setInt(2, 2);
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from flow.flow_targets");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from flow.flow_targets");
 
         Assertion.assertEquals(expectedTable, actualTable);
 
@@ -119,7 +114,6 @@ public class ProcedureStorageTest extends DBUnitbase {
     -Takes capture_id and storage_id
     */
     public void testStorageCaptureLinkage() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLProcedureStorage/procedureStorageExpectedTestData2.xml"));
 
         ITable expectedTable = expectedDataSet.getTable("cfe_18.capture_def_x_flow_targets");
@@ -129,7 +123,7 @@ public class ProcedureStorageTest extends DBUnitbase {
         stmnt.setInt(2, 2);
         stmnt.execute();
 
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_x_flow_targets");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_x_flow_targets");
 
         Assertion.assertEquals(expectedTable, actualTable);
     }
@@ -140,8 +134,6 @@ public class ProcedureStorageTest extends DBUnitbase {
     -Throws 42000 when not existing
      */
     public void testStorageMissingStorageLinkage() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL flow.add_storage_for_capture(?,?)}");
             stmnt.setInt(1, 1);
@@ -158,8 +150,6 @@ public class ProcedureStorageTest extends DBUnitbase {
     -Throws 45000 when indifferent
   */
     public void testStorageDifferentFlowLinkage() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL flow.add_storage_for_capture(?,?)}");
             stmnt.setInt(1, 1);
@@ -176,8 +166,6 @@ public class ProcedureStorageTest extends DBUnitbase {
     -Throws 45000 when capture is missing
      */
     public void testStorageMissingCaptureLinkage() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             CallableStatement stmnt = conn.prepareCall("{CALL flow.add_storage_for_capture(?,?)}");
             stmnt.setInt(1, 500);

--- a/src/test/java/com/teragrep/cfe18/procedureTests/TriggerHostFileTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/TriggerHostFileTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -76,8 +74,6 @@ public class TriggerHostFileTest extends DBUnitbase {
     This test bounces the trigger indicating that the trigger is in place.
     */
     public void testHostTriggerBounce() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             Statement stmnt = conn.createStatement();
             stmnt.addBatch("insert into location.host_group_x_host values(60,2,11,'cfe')");
@@ -90,7 +86,6 @@ public class TriggerHostFileTest extends DBUnitbase {
     }
 
     public void testHostTriggerAccept() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLTriggersHostXCapture/triggerHostExpectedData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("location.host_group_x_host");
 
@@ -102,15 +97,10 @@ public class TriggerHostFileTest extends DBUnitbase {
 
 
         // Fetch database data after executing your code
-
-        ITable actualTable = getConnection().createQueryTable("result", "select * from location.host_group_x_host");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from location.host_group_x_host");
 
         // Load expected data from an XML dataset
         // Assert actual database table match expected table
         Assertion.assertEquals(expectedTable, actualTable);
-
-
     }
-
-
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/TriggerHostGroupCaptureGroupFileTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/TriggerHostGroupCaptureGroupFileTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -76,8 +74,6 @@ public class TriggerHostGroupCaptureGroupFileTest extends DBUnitbase {
     This test bounces the trigger indicating that the trigger is in place.
     */
     public void testHostTriggerBounce() throws SQLException, Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
             Statement stmnt = conn.createStatement();
             stmnt.addBatch("insert into cfe_18.host_groups_x_capture_def_group values(61,2,1)");
@@ -93,8 +89,6 @@ public class TriggerHostGroupCaptureGroupFileTest extends DBUnitbase {
     This test checks acceptance of new junction between host and log groups.
      */
     public void testHostTriggerAccept() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         // Load the modified data for comparison
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLTriggersHostXCapture/triggerGXGExpectedTestData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.host_groups_x_capture_def_group");
@@ -106,13 +100,9 @@ public class TriggerHostGroupCaptureGroupFileTest extends DBUnitbase {
         stmnt.executeBatch();
 
         // Fetch database data after executing your code
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.host_groups_x_capture_def_group");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.host_groups_x_capture_def_group");
 
         // Assert actual database table match expected table
         Assertion.assertEquals(expectedTable, actualTable);
-
-
     }
-
-
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/TriggerTagTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/TriggerTagTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.Assertions;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -75,8 +73,6 @@ public class TriggerTagTest extends DBUnitbase {
     This test bounces the trigger indicating that the trigger is in place.
     */
     public void testTagTriggerBounce() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
-
         // Execute the tested code that modify the database here
         // execute statement here
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
@@ -86,15 +82,12 @@ public class TriggerTagTest extends DBUnitbase {
             stmnt.executeBatch();
         });
         Assertions.assertEquals("17001", state.getSQLState());
-
-
     }
 
     /*
     Test for checking that the trigger allows values which do not conflict.
      */
     public void testTagTriggerAccept() throws Exception {
-        Connection conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         IDataSet expectedDataSet = new FlatXmlDataSetBuilder().build(new File("src/test/resources/XMLTriggersHostXCapture/triggerTagExpectedData1.xml"));
         ITable expectedTable = expectedDataSet.getTable("cfe_18.capture_def_group_x_capture_def");
 
@@ -107,14 +100,10 @@ public class TriggerTagTest extends DBUnitbase {
         stmnt.executeBatch();
 
         // Fetch database data after executing your code
-        ITable actualTable = getConnection().createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
+        ITable actualTable = databaseConnection.createQueryTable("result", "select * from cfe_18.capture_def_group_x_capture_def");
 
         // Load expected data from an XML dataset
         // Assert actual database table match expected table
         Assertion.assertEquals(expectedTable, actualTable);
-
-
     }
-
-
 }

--- a/src/test/java/com/teragrep/cfe18/testData/DBInformation.java
+++ b/src/test/java/com/teragrep/cfe18/testData/DBInformation.java
@@ -46,6 +46,8 @@
 package com.teragrep.cfe18.testData;
 
 import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
@@ -62,6 +64,11 @@ class DBInformation {
         conn = DriverManager.getConnection(this.DBUNIT_CONNECTION_URL + "?" + "user=" + this.DBUNIT_USERNAME + "&password=" + this.DBUNIT_PASSWORD);
         Flyway flyway = Flyway.configure().dataSource(DBUNIT_CONNECTION_URL + "/cfe_18", DBUNIT_USERNAME, DBUNIT_PASSWORD).load();
         flyway.migrate();
+    }
+
+    @AfterAll
+    public void cleanup() {
+        Assertions.assertDoesNotThrow(conn::close);
     }
 
     protected String DBUNIT_DRIVER_CLASS = System.getProperty("tests.dbunit.driver.class");


### PR DESCRIPTION
Some general cleanup for tests and closes connections so it should no longer print errors like this in mariadb logs

```sh
2024-03-21 11:28:37 2444 [Warning] Aborted connection 2444 to db: 'unconnected' user: 'testuser' host: 'localhost' (Got an error reading communication packets)
2024-03-21 11:28:37 2450 [Warning] Aborted connection 2450 to db: 'unconnected' user: 'testuser' host: 'localhost' (Got an error reading communication packets)
2024-03-21 11:28:37 2454 [Warning] Aborted connection 2454 to db: 'unconnected' user: 'testuser' host: 'localhost' (Got an error reading communication packets)
2024-03-21 11:28:37 2452 [Warning] Aborted connection 2452 to db: 'unconnected' user: 'testuser' host: 'localhost' (Got an error reading communication packets)
```