### PR TITLE
Specify that captureMeta is only for file-based captures

### DIFF
--- a/src/docs/examples/capture/captureMeta.adoc
+++ b/src/docs/examples/capture/captureMeta.adoc
@@ -41,7 +41,7 @@ Teragrep, the applicable Commercial License may apply to this file if you as
 a licensee so wish it.
 ////
 
-= Capture Meta
+= Example API calls for integration
 :toc:
 :toclevels: 4
 :icons: font
@@ -124,5 +124,5 @@ HTTP Response code: 500
 ----
 
 == Why?
-* (file)CaptureMeta provides metadata for Captures
-* Needs to be inserted before the Captures, so that the ID for the CaptureMeta can be linked to a Capture
+* CaptureMeta provides metadata for link:fileCaptureDefinition.adoc[file-based captures]
+* Needs to be inserted before the Captures, so that the ID for the CaptureMeta can be linked to a link:fileCaptureDefinition.adoc[Capture]

--- a/src/docs/examples/main.adoc
+++ b/src/docs/examples/main.adoc
@@ -48,10 +48,10 @@ a licensee so wish it.
 
 == Order of usage
 . link:hub.adoc[Hub/s]
-. link:capture/captureMeta.adoc[Capture metadata]
 . link:flow.adoc[Flows]
 . link:sink.adoc[Sinks]
 . Captures
+.. link:capture/captureMeta.adoc[Capture metadata for file-based captures]
 .. CaptureDefinition
 ... link:capture/fileCaptureDefinition.adoc[file-based captures]
 ... link:capture/relpCaptureDefinition.adoc[RELP-based captures]


### PR DESCRIPTION
Fixes #123

- The captureMeta step is moved under the Captures step, with the captureMeta being the first sub-step
- Tries to be more specific in the usage of the captureMeta, that it is only for file-based captures