### PR TITLE
Add copyright comment to all documentation files

### DIFF
--- a/src/docs/examples/capture/captureGroup.adoc
+++ b/src/docs/examples/capture/captureGroup.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Capture Group
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/captureMeta.adoc
+++ b/src/docs/examples/capture/captureMeta.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Capture Meta
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/fileCaptureDefinition.adoc
+++ b/src/docs/examples/capture/fileCaptureDefinition.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Capture Definition
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/relpCaptureDefinition.adoc
+++ b/src/docs/examples/capture/relpCaptureDefinition.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Capture Definition
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/storage.adoc
+++ b/src/docs/examples/capture/storage.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Storage
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/storageCapture.adoc
+++ b/src/docs/examples/capture/storageCapture.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Storage Capture
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/storageFlow.adoc
+++ b/src/docs/examples/capture/storageFlow.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Storage Flow
 :toc:
 :toclevels: 4

--- a/src/docs/examples/capture/tag.adoc
+++ b/src/docs/examples/capture/tag.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Calculating the tag
 
 The tag is calculated from a Capture's tag_path using MD5 hashing.

--- a/src/docs/examples/flow.adoc
+++ b/src/docs/examples/flow.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Flow
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostFile.adoc
+++ b/src/docs/examples/host/hostFile.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = File-based Host
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostGroup.adoc
+++ b/src/docs/examples/host/hostGroup.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Host Group
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostMeta.adoc
+++ b/src/docs/examples/host/hostMeta.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Metadata for Host
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostMetaIP.adoc
+++ b/src/docs/examples/host/hostMetaIP.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = IP addresses for Host metadata
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostMetaInterface.adoc
+++ b/src/docs/examples/host/hostMetaInterface.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Interfaces for Host metadata
 :toc:
 :toclevels: 4

--- a/src/docs/examples/host/hostRelp.adoc
+++ b/src/docs/examples/host/hostRelp.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = File-based Host
 :toc:
 :toclevels: 4

--- a/src/docs/examples/hub.adoc
+++ b/src/docs/examples/hub.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Hub
 :toc:
 :toclevels: 4

--- a/src/docs/examples/linkage.adoc
+++ b/src/docs/examples/linkage.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Linkage
 :toc:
 :toclevels: 4

--- a/src/docs/examples/main.adoc
+++ b/src/docs/examples/main.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Start Here
 :toc:
 :icons: font

--- a/src/docs/examples/sink.adoc
+++ b/src/docs/examples/sink.adoc
@@ -1,3 +1,46 @@
+////
+Integration main data management for Teragrep
+Copyright (C) 2025 Suomen Kanuuna Oy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+
+Additional permission under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining it
+with other code, such other code is not for that reason alone subject to any
+of the requirements of the GNU Affero GPL version 3 as long as this Program
+is the same Program as licensed from Suomen Kanuuna Oy without any additional modifications.
+
+Supplemented terms under GNU Affero General Public License version 3
+section 7
+
+Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+versions must be marked as "Modified version of" The Program.
+
+Names of the licensors and authors may not be used for publicity purposes.
+
+No rights are granted for use of trade names, trademarks, or service marks
+which are in The Program if any.
+
+Licensee must indemnify licensors and authors for any liability that these
+contractual assumptions impose on licensors and authors.
+
+To the extent this program is licensed as part of the Commercial versions of
+Teragrep, the applicable Commercial License may apply to this file if you as
+a licensee so wish it.
+////
+
 = Flow
 :toc:
 :toclevels: 4


### PR DESCRIPTION
Fixes #125

- Uses a comment block for the .adoc files
- Copyright year is 2025