### PR TITLE
File Processing Type endpoints refactored separately

### DIFF
--- a/src/main/java/com/teragrep/cfe18/FileProcessingTypeMapper.java
+++ b/src/main/java/com/teragrep/cfe18/FileProcessingTypeMapper.java
@@ -52,16 +52,17 @@ import java.util.List;
 
 @Mapper
 public interface FileProcessingTypeMapper {
-    FileProcessing get(int id, Integer version);
 
     FileProcessing create(
             String template,
             String rule,
             String name,
-            String inputtype,
-            String inputvalue);
+            String inputType,
+            String inputValue);
+
+    FileProcessing get(int id, Integer version);
 
     List<FileProcessing> getAll(Integer version);
 
-    FileProcessing delete(int id);
+    void delete(Integer id);
 };

--- a/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
@@ -69,9 +69,10 @@ import java.sql.SQLException;
 import java.util.List;
 
 @RestController
-@RequestMapping(path = "file/capture")
+@RequestMapping(path = "file/capture/meta")
 @SecurityRequirement(name = "api")
 public class FileProcessingTypeController {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(FileProcessingTypeController.class);
 
     @Autowired
@@ -83,54 +84,8 @@ public class FileProcessingTypeController {
     @Autowired
     FileProcessingTypeMapper fileProcessingTypeMapper;
 
-
-    @RequestMapping(path = "/meta/{id}", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch file processing type by id")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "File processing type retrieved",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FileProcessing.class))}),
-            @ApiResponse(responseCode = "400", description = "File processing type does not exist with the given id",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-                })
-    public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            FileProcessing fc = fileProcessingTypeMapper.get(id,version);
-            return new ResponseEntity<>(fc, HttpStatus.OK);
-        } catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                // fail-safe if SQL error but not 45000 type
-                jsonErr.put("id", id);
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given id");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-
-    // Get ALL endpoint
-    @RequestMapping(path = "/meta/", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch all file processing types", description = "Will return empty list if there are no file processing types to fetch")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "File processing types fetched",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FileProcessing.class))})
-                })
-    public List<FileProcessing> getAll(@RequestParam(required = false) Integer version) {
-        return fileProcessingTypeMapper.getAll(version);
-    }
-
-
-    @RequestMapping(path = "/meta/rule", method = RequestMethod.PUT, produces = "application/json")
-    @Operation(summary = "Insert file processing type for file based capture")
+    @RequestMapping(path = "", method = RequestMethod.PUT, produces = "application/json")
+    @Operation(summary = "Create file processing type for file based capture")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "New file processing type created",
                     content = {@Content(mediaType = "application/json",
@@ -152,50 +107,96 @@ public class FileProcessingTypeController {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("id", n.getId());
             jsonObject.put("message", "New file processing type created");
-
             return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
         } catch (RuntimeException ex) {
             LOGGER.error(ex.getMessage());
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", newFileProcessing.getId());
+            jsonErr.put("message", ex.getCause().getMessage());
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
-    // Delete
-    @RequestMapping(path = "meta/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(path = "/{id}", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch file processing type by id")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "File processing type retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FileProcessing.class))}),
+            @ApiResponse(responseCode = "404", description = "File processing type does not exist",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
+                })
+    public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
+        try {
+            FileProcessing fc = fileProcessingTypeMapper.get(id,version);
+            return new ResponseEntity<>(fc, HttpStatus.OK);
+        } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().getMessage());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    jsonErr.put("message", "Record does not exist with the given id");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping(path = "", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch all file processing types", description = "Will return empty list if there are no file processing types to fetch")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FileProcessing.class))})})
+    public List<FileProcessing> getAll(@RequestParam(required = false) Integer version) {
+        return fileProcessingTypeMapper.getAll(version);
+    }
+
+    @RequestMapping(path = "/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Delete file processing type")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "File processing type deleted",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FileProcessing.class))}),
-            @ApiResponse(responseCode = "400", description = "File processing type is being used OR file processing type does not exist",
+            @ApiResponse(responseCode = "400", description = "File processing type is being used",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "File processing type does not exist",
                     content = @Content),
             @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
     })
-    public ResponseEntity<String> delete(@PathVariable("id") int id) {
+    public ResponseEntity<String> delete(@PathVariable("id") Integer id) {
         LOGGER.info("Deleting file processing type  <[{}]>",id);
-        JSONObject jsonErr = new JSONObject();
         try {
             fileProcessingTypeMapper.delete(id);
             JSONObject j = new JSONObject();
             j.put("id", id);
-            j.put("message", "File processing type deleted.");
+            j.put("message", "File processing type deleted");
             return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().getMessage());
             final Throwable cause = ex.getCause();
             if (cause instanceof SQLException) {
                 LOGGER.error((cause).getMessage());
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("23000")) {
-                    jsonErr.put("id", id);
                     jsonErr.put("message", "Is in use");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
                 } else if (state.equals("45000")) {
-                    jsonErr.put("id", id);
                     jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
                 }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
             }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
@@ -90,10 +90,8 @@ public class FileProcessingTypeController {
             @ApiResponse(responseCode = "201", description = "New file processing type created",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FileProcessing.class))}),
-            @ApiResponse(responseCode = "400", description = "Inputvalue must be regex or newline",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
+            @ApiResponse(responseCode = "400", description = "Inputvalue must be regex or newline", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<String> create(@RequestBody FileProcessing newFileProcessing) {
         LOGGER.info("About to insert <[{}]>", newFileProcessing);
         try {
@@ -123,10 +121,8 @@ public class FileProcessingTypeController {
             @ApiResponse(responseCode = "200", description = "File processing type retrieved",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FileProcessing.class))}),
-            @ApiResponse(responseCode = "404", description = "File processing type does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-                })
+            @ApiResponse(responseCode = "404", description = "File processing type does not exist", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
         try {
             FileProcessing fc = fileProcessingTypeMapper.get(id,version);
@@ -141,7 +137,7 @@ public class FileProcessingTypeController {
                 LOGGER.error((cause).getMessage());
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given id");
+                    jsonErr.put("message", "Record does not exist");
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
                 }
             }
@@ -165,12 +161,9 @@ public class FileProcessingTypeController {
             @ApiResponse(responseCode = "200", description = "File processing type deleted",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FileProcessing.class))}),
-            @ApiResponse(responseCode = "400", description = "File processing type is being used",
-                    content = @Content),
-            @ApiResponse(responseCode = "404", description = "File processing type does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
+            @ApiResponse(responseCode = "409", description = "File processing type is being used", content = @Content),
+            @ApiResponse(responseCode = "404", description = "File processing type does not exist", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<String> delete(@PathVariable("id") Integer id) {
         LOGGER.info("Deleting file processing type  <[{}]>",id);
         try {
@@ -190,7 +183,7 @@ public class FileProcessingTypeController {
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("23000")) {
                     jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
                 } else if (state.equals("45000")) {
                     jsonErr.put("message", "Record does not exist");
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);

--- a/src/main/resources/com/teragrep/cfe18/FileProcessingTypeMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/FileProcessingTypeMapper.xml
@@ -4,51 +4,54 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.teragrep.cfe18.FileProcessingTypeMapper">
 
-    <!-- fetch processing type by name -->
-    <select id="get" resultMap="processingType" statementType="CALLABLE">
+    <!-- insert             ( meta_template_filename VARCHAR(255), meta_rule VARCHAR(1000),
+                                                    meta_rule_name VARCHAR(255),
+                                                    meta_inputtype ENUM ('regex','newline'),
+                                                    meta_inputvalue VARCHAR(255) ) -->
+    <select id="create" resultMap="insertedID" statementType="CALLABLE">
+        {CALL
+        cfe_18.insert_file_processing_type(#{param1},#{param2},#{param3},#{param4},#{param5})}
+    </select>
+
+
+    <!-- get                ( id INT, tx_id INT )  -->
+    <select id="get" resultMap="getFileProcessingType" statementType="CALLABLE">
         {CALL cfe_18.select_file_processing_type(#{param1},#{param2})}
     </select>
-    <resultMap type="com.teragrep.cfe18.handlers.entities.FileProcessing" id="processingType">
-        <result property="id" column="id"/>
-        <result property="name" column="name"/>
-        <result property="inputtype" column="inputtype"/>
-        <result property="inputvalue" column="inputvalue"/>
-        <result property="ruleset" column="ruleset"/>
-        <result property="template" column="template"/>
+    <resultMap type="com.teragrep.cfe18.handlers.entities.FileProcessing" id="getFileProcessingType">
+        <result property="id"               column="id"/>
+        <result property="name"             column="name"/>
+        <result property="inputtype"        column="inputtype"/>
+        <result property="inputvalue"       column="inputvalue"/>
+        <result property="ruleset"          column="ruleset"/>
+        <result property="template"         column="template"/>
     </resultMap>
 
 
-    <!-- Insert new one -->
-    <select id="create" resultMap="insertedId" statementType="CALLABLE">
-        {CALL
-        cfe_18.insert_file_processing_type(#{arg0},#{arg1},#{arg2},#{arg3},#{arg4})}
-    </select>
-    <resultMap id="insertedId" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
-        <result property="id" column="id"/>
-    </resultMap>
-
-    <!-- GET ALL -->
-    <select id="getAll" resultMap="allProcessingType" statementType="CALLABLE">
+    <!-- GET ALL            ( tx_id INT )-->
+    <select id="getAll" resultMap="all" statementType="CALLABLE">
         {CALL cfe_18.select_all_file_processing_types(#{param1})}
     </select>
-    <resultMap id="allProcessingType" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
-        <result property="id" column="id"/>
-        <result property="name" column="name"/>
-        <result property="inputtype" column="inputtype"/>
-        <result property="inputvalue" column="inputvalue"/>
-        <result property="ruleset" column="ruleset"/>
-        <result property="template" column="template"/>
+    <resultMap id="all" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
+        <result property="id"               column="id"/>
+        <result property="name"             column="name"/>
+        <result property="inputtype"        column="inputtype"/>
+        <result property="inputvalue"       column="inputvalue"/>
+        <result property="ruleset"          column="ruleset"/>
+        <result property="template"         column="template"/>
     </resultMap>
 
-    <!-- delete -->
+
+    <!-- delete             ( p_id INT ) -->
     <select id="delete" statementType="CALLABLE">
         {call cfe_18.delete_file_processing_type(#{param1})}
     </select>
 
-    <resultMap id="deletedId" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
-        <result property="id" column="id"/>
-    </resultMap>
 
+    <!-- ID return map -->
+    <resultMap id="insertedID" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
+        <result property="id"                       column="id"/>
+    </resultMap>
 
 </mapper>
 

--- a/src/main/resources/com/teragrep/cfe18/FileProcessingTypeMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/FileProcessingTypeMapper.xml
@@ -9,8 +9,7 @@
                                                     meta_inputtype ENUM ('regex','newline'),
                                                     meta_inputvalue VARCHAR(255) ) -->
     <select id="create" resultMap="insertedID" statementType="CALLABLE">
-        {CALL
-        cfe_18.insert_file_processing_type(#{param1},#{param2},#{param3},#{param4},#{param5})}
+        {CALL cfe_18.insert_file_processing_type(#{param1},#{param2},#{param3},#{param4},#{param5})}
     </select>
 
 
@@ -50,7 +49,7 @@
 
     <!-- ID return map -->
     <resultMap id="insertedID" type="com.teragrep.cfe18.handlers.entities.FileProcessing">
-        <result property="id"                       column="id"/>
+        <result property="id"               column="id"/>
     </resultMap>
 
 </mapper>

--- a/src/main/resources/db/migration/R__Procedure_Select_File_Processing_Type.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_File_Processing_Type.sql
@@ -43,9 +43,9 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-use cfe_18;
+USE cfe_18;
 DELIMITER //
-CREATE OR REPLACE PROCEDURE select_file_processing_type(id int,tx_id int)
+CREATE OR REPLACE PROCEDURE select_file_processing_type(id INT, tx_id INT)
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION
         BEGIN
@@ -53,24 +53,26 @@ BEGIN
             RESIGNAL;
         END;
     START TRANSACTION;
-            if(tx_id) is null then
-             set @time = (select max(transaction_id) from mysql.transaction_registry);
-        else
-             set @time=tx_id;
-        end if;
-        if ((select count(id) from cfe_18.file_processing_type for system_time as of transaction @time fpt where fpt.id = id)=0) then
-            SELECT JSON_OBJECT('id', id, 'message', 'File processing type does not exist') into @pt;
-            signal sqlstate '45000' set message_text = @pt;
-        end if;
+    IF (tx_id) IS NULL THEN
+        SET @time = (SELECT MAX(transaction_id) FROM mysql.transaction_registry);
+    ELSE
+        SET @time = tx_id;
+    END IF;
+    IF ((SELECT COUNT(id)
+         FROM cfe_18.file_processing_type FOR SYSTEM_TIME AS OF TRANSACTION @time fpt
+         WHERE fpt.id = id) = 0) THEN
+        SELECT JSON_OBJECT('id', id, 'message', 'File processing type does not exist') INTO @pt;
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @pt;
+    END IF;
 
-        select id          as id,
-               name        as name,
-               inputtype   as inputtype,
-               inputvalue  as inputvalue,
-               ruleset     as ruleset,
-               template    as template
-        from cfe_18.file_processing_type for system_time as of transaction @time fpt where fpt.id=id;
-
+    SELECT fpt.id         AS id,
+           fpt.name       AS name,
+           fpt.inputtype  AS inputtype,
+           fpt.inputvalue AS inputvalue,
+           fpt.ruleset    AS ruleset,
+           fpt.template   AS template
+    FROM cfe_18.file_processing_type FOR SYSTEM_TIME AS OF TRANSACTION @time fpt
+    WHERE fpt.id = id;
     COMMIT;
 END;
 //

--- a/src/test/java/com/teragrep/cfe18/controllerTests/CaptureFileControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/CaptureFileControllerTest.java
@@ -99,7 +99,7 @@ public final class CaptureFileControllerTest extends TestSpringBootInformation {
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta/rule");
+        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta");
         // set requestEntity to the put request
         request.setEntity(requestEntity);
         // Header

--- a/src/test/java/com/teragrep/cfe18/controllerTests/FileProcessingTypeControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/FileProcessingTypeControllerTest.java
@@ -62,11 +62,13 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-
 
 import java.util.ArrayList;
 
@@ -85,13 +87,9 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
     private int port;
 
 
-    // Testing if processing type can be added via endpoint
-
     @Test
     @Order(1)
-    public void testFileProcessingType() throws Exception {
-
-
+    public void testFileProcessingType() {
         FileProcessing file = new FileProcessing();
         file.setInputtype(FileProcessing.InputType.regex);
         file.setInputvalue("normalregex");
@@ -99,9 +97,7 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         file.setName("name1");
         file.setTemplate("regex.moustache");
 
-
         String json = gson.toJson(file);
-
 
         // forms the json to requestEntity
         StringEntity requestEntity = new StringEntity(
@@ -109,29 +105,29 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta/rule");
+        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta");
         // set requestEntity to the put request
         request.setEntity(requestEntity);
         // Header
         request.setHeader("Authorization", "Bearer " + token);
 
         // Get the response from endpoint
-        HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+        HttpResponse httpResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
 
         // Get the entity from response
         HttpEntity entity = httpResponse.getEntity();
 
         // Entity response string
-        String responseString = EntityUtils.toString(entity);
+        String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity));
 
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseString);
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "New file processing type created";
 
         // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
 
         // Assertions
         assertEquals(expected, actual);
@@ -141,10 +137,9 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
 
     }
 
-    // When getting the values back it should have ID carried with the object created.
     @Test
     @Order(2)
-    public void testGetFileProcessingTypeByName() throws Exception {
+    public void testGetFileProcessingTypeById() {
 
         FileProcessing file2 = new FileProcessing();
         file2.setInputtype(FileProcessing.InputType.regex);
@@ -163,13 +158,13 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta/rule");
+        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta");
         // set requestEntity to the put request
         request.setEntity(requestEntity);
         // Header
         request.setHeader("Authorization", "Bearer " + token);
 
-        HttpClientBuilder.create().build().execute(request);
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
 
         FileProcessing file = new FileProcessing();
         file.setInputtype(FileProcessing.InputType.regex);
@@ -182,24 +177,23 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         String json = gson.toJson(file);
 
         // Asserting get request
-        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/file/capture/meta/"+1);
+        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/file/capture/meta/" + 1);
 
         requestGet.setHeader("Authorization", "Bearer " + token);
 
-        HttpResponse responseGet = HttpClientBuilder.create().build().execute(requestGet);
+        HttpResponse responseGet = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestGet));
 
         HttpEntity entityGet = responseGet.getEntity();
 
-        String responseStringGet = EntityUtils.toString(entityGet, "UTF-8");
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
 
         assertEquals(json, responseStringGet);
         assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
     }
 
-
     @Test
     @Order(3)
-    public void testGetAllFileProcessingTypesTypes() throws Exception {
+    public void testGetAllFileProcessingTypes() {
         GsonBuilder gson2 = new GsonBuilder().serializeNulls();
         Gson real = gson2.create();
         // Declare list of expected values
@@ -222,15 +216,14 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta/rule");
+        HttpPut request = new HttpPut("http://localhost:" + port + "/file/capture/meta");
         // set requestEntity to the put request
         request.setEntity(requestEntity);
         // Header
         request.setHeader("Authorization", "Bearer " + token);
 
         // Get the response from endpoint
-        HttpClientBuilder.create().build().execute(request);
-
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
 
         FileProcessing file2 = new FileProcessing();
         file2.setId(1);
@@ -245,47 +238,44 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         expected.add(file1);
         String expectedJson = real.toJson(expected);
 
-        // Test Get ALL
-
-        // Asserting get request
-        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/file/capture/meta/");
+        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/file/capture/meta");
 
         requestGet.setHeader("Authorization", "Bearer " + token);
 
-        HttpResponse responseGet = HttpClientBuilder.create().build().execute(requestGet);
+        HttpResponse responseGet = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestGet));
 
         HttpEntity entityGet = responseGet.getEntity();
 
-        String responseStringGet = EntityUtils.toString(entityGet, "UTF-8");
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
 
-        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        // Asserting
         assertEquals(expectedJson, responseStringGet);
+        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
     }
 
-    // Delete endpoint tests
     @Test
     @Order(4)
-    public void testDeleteProcessingType() throws Exception {
+    public void testDeleteProcessingType() {
 
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/"+2);
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/" + 2);
 
         // Header
         delete.setHeader("Authorization", "Bearer " + token);
 
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
 
         HttpEntity entityDelete = deleteResponse.getEntity();
 
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
 
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGet));
 
         // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "File processing type deleted.";
+        String expected = "File processing type deleted";
 
         assertEquals(expected, actual);
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
@@ -294,36 +284,36 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
 
     @Test
     @Order(5)
-    public void testDeleteNonExistentProcessingType() throws Exception {
+    public void testDeleteNonExistentProcessingType() {
 
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/"+2222);
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/" + 2222);
 
         // Header
         delete.setHeader("Authorization", "Bearer " + token);
 
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
 
         HttpEntity entityDelete = deleteResponse.getEntity();
 
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
 
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGet));
 
         // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
 
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
         assertEquals(expected, actual);
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
 
     }
 
     @Test
     @Order(6)
-    public void testDeleteProcessingTypeInUse() throws Exception {
+    public void testDeleteProcessingTypeInUse() {
         // add flow and sink
 
         Flow flow = new Flow();
@@ -342,14 +332,14 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         // Header
         request2.setHeader("Authorization", "Bearer " + token);
 
-        HttpClientBuilder.create().build().execute(request2);
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request2));
 
         // insert sink
 
         Sink sink = new Sink();
-        sink.setFlowId(1);
+        sink.setFlow("capFlow");
         sink.setPort("cap");
-        sink.setIpAddress("capsink");
+        sink.setIp_address("capsink");
         sink.setProtocol("prot");
 
         String json1 = gson.toJson(sink);
@@ -360,14 +350,14 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request1 = new HttpPut("http://localhost:" + port + "/sink");
+        HttpPut request1 = new HttpPut("http://localhost:" + port + "/sink/details");
         // set requestEntity to the put request
         request1.setEntity(requestEntity1);
         // Header
         request1.setHeader("Authorization", "Bearer " + token);
 
         // Get the response from endpoint
-        HttpClientBuilder.create().build().execute(request1);
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request1));
 
         CaptureFile captureFile = new CaptureFile();
         captureFile.setId(1);
@@ -398,24 +388,24 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         request3.setHeader("Authorization", "Bearer " + token);
 
         // Get the response from endpoint
-        HttpClientBuilder.create().build().execute(request3);
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request3));
 
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/"+1);
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/file/capture/meta/" + 1);
 
         // Header
         delete.setHeader("Authorization", "Bearer " + token);
 
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
 
         HttpEntity entityDelete = deleteResponse.getEntity();
 
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
 
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGet));
 
         // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Is in use";


### PR DESCRIPTION
- Void on delete
- Procedures named accordingly
- Controllers named accordingly

More info on PR #155 

Currently RESTful path is `file/capture/meta` but should maybe differ a bit so that there is no confusion with `capture/meta` path.
Maybe something like `capture/processing` or `file/capture/processing`. Thoughts? @kortemik 