### PR TITLE
Flow Storage endpoints refactored separately

### DIFF
--- a/src/main/java/com/teragrep/cfe18/FlowStorageMapper.java
+++ b/src/main/java/com/teragrep/cfe18/FlowStorageMapper.java
@@ -53,20 +53,13 @@ import org.apache.ibatis.annotations.Mapper;
 import java.util.List;
 
 @Mapper
-public interface StorageMapper {
-    Storage create(Storage.StorageType cfeType, String storageName);
+public interface FlowStorageMapper {
+    FlowStorage create(int flowId, int storageId);
 
-    CaptureStorage createCaptureStorage(int capture_id, int storage_id);
+    List<FlowStorage> get(int flowId, Integer version);
 
-    Storage getStorage(int id, Integer version);
+    List<FlowStorage> getAll(Integer version);
 
-    List<CaptureStorage> getCaptureStorage(int captureId, Integer version);
+    void delete(int flowId, int id);
 
-    List<Storage> getAll(Integer version);
-
-    List<CaptureStorage> getAllCapture(Integer version);
-
-    Storage delete(int id);
-
-    CaptureStorage deleteCaptureStorage(int captureId, int storageId);
 }

--- a/src/main/java/com/teragrep/cfe18/FlowStorageMapper.java
+++ b/src/main/java/com/teragrep/cfe18/FlowStorageMapper.java
@@ -60,6 +60,6 @@ public interface FlowStorageMapper {
 
     List<FlowStorage> getAll(Integer version);
 
-    void delete(int flowId, int id);
+    void delete(int flowId, int storageId);
 
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/FlowStorageController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FlowStorageController.java
@@ -92,11 +92,8 @@ public class FlowStorageController {
             @ApiResponse(responseCode = "201", description = "New flow storage created",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "SQL Constraint error",
-                    content = @Content),
-            @ApiResponse(responseCode = "404", description = "Flow or Storage does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+            @ApiResponse(responseCode = "404", description = "Flow or Storage does not exist", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<String> create(@RequestBody FlowStorage newFlowStorage) {
         LOGGER.info("About to insert <[{}]>", newFlowStorage);
         try {
@@ -118,7 +115,7 @@ public class FlowStorageController {
                 LOGGER.error((cause).getMessage());
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("45000")) {
-                    jsonErr.put("message", "Flow or Storage does not exist");
+                    jsonErr.put("message", "Record does not exist");
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
                 }
             }
@@ -132,9 +129,8 @@ public class FlowStorageController {
             @ApiResponse(responseCode = "200", description = "Flow storage retrieved",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "Flow storage does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+            @ApiResponse(responseCode = "404", description = "Flow storage does not exist", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
         try {
             List<FlowStorage> fs = flowStorageMapper.get(id, version);
@@ -167,29 +163,27 @@ public class FlowStorageController {
         return flowStorageMapper.getAll(version);
     }
 
-    @RequestMapping(path = "/{flowId}/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(path = "/{flowId}/{storageId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Delete flow storage")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Flow storage deleted",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "409", description = "Flow storage is being used",
-                    content = @Content),
-            @ApiResponse(responseCode = "404", description = "Flow storage does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
-    public ResponseEntity<String> delete(@PathVariable("flowId") int flowId, @PathVariable("id") int id) {
-        LOGGER.info("Deleting flow Storage with id <[{}]>", id);
+            @ApiResponse(responseCode = "409", description = "Flow storage is being used", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Flow storage does not exist", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Internal server error, contact admin", content = @Content)})
+    public ResponseEntity<String> delete(@PathVariable("flowId") int flowId, @PathVariable("storageId") int storageId) {
+        LOGGER.info("Deleting flow Storage with id <[{}]>", storageId);
         try {
-            flowStorageMapper.delete(flowId, id);
+            flowStorageMapper.delete(flowId, storageId);
             JSONObject j = new JSONObject();
-            j.put("id", id);
+            j.put("id", storageId);
             j.put("message", "Flow storage deleted");
             return new ResponseEntity<>(j.toString(), HttpStatus.OK);
         } catch (RuntimeException ex) {
             LOGGER.error(ex.getMessage());
             JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
+            jsonErr.put("id", storageId);
             jsonErr.put("message", ex.getCause().getMessage());
             final Throwable cause = ex.getCause();
             if (cause instanceof SQLException) {
@@ -203,11 +197,9 @@ public class FlowStorageController {
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
                 }
             }
-
             return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
         }
     }
-
 }
 
 

--- a/src/main/java/com/teragrep/cfe18/handlers/FlowStorageController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FlowStorageController.java
@@ -1,0 +1,213 @@
+/*
+ * Integration main data management for Teragrep
+ * Copyright (C) 2021  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cfe18.handlers;
+
+import com.teragrep.cfe18.FlowStorageMapper;
+import com.teragrep.cfe18.StorageMapper;
+import com.teragrep.cfe18.handlers.entities.CaptureStorage;
+import com.teragrep.cfe18.handlers.entities.FileProcessing;
+import com.teragrep.cfe18.handlers.entities.FlowStorage;
+import com.teragrep.cfe18.handlers.entities.Storage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.json.JSONObject;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/storage/flow")
+@SecurityRequirement(name = "api")
+public class FlowStorageController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowStorageController.class);
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    SqlSessionTemplate sqlSessionTemplate;
+
+    @Autowired
+    FlowStorageMapper flowStorageMapper;
+
+    @RequestMapping(path = "", method = RequestMethod.PUT, produces = "application/json")
+    @Operation(summary = "Create new flow storage")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "New flow storage created",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FlowStorage.class))}),
+            @ApiResponse(responseCode = "400", description = "SQL Constraint error",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Flow or Storage does not exist",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+    public ResponseEntity<String> create(@RequestBody FlowStorage newFlowStorage) {
+        LOGGER.info("About to insert <[{}]>", newFlowStorage);
+        try {
+            FlowStorage fs = flowStorageMapper.create(
+                    newFlowStorage.getFlowId(),
+                    newFlowStorage.getStorageId());
+            LOGGER.debug("Values returned <[{}]>", fs);
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("id", fs.getId());
+            jsonObject.put("message", "New flow storage created");
+            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+        } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", newFlowStorage.getId());
+            jsonErr.put("message", ex.getCause().toString());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    jsonErr.put("message", "Flow or Storage does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping(path = "/{id}", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch flow storage")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Flow storage retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FlowStorage.class))}),
+            @ApiResponse(responseCode = "400", description = "Flow storage does not exist",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+    public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
+        try {
+            List<FlowStorage> fs = flowStorageMapper.get(id, version);
+            return new ResponseEntity<>(fs, HttpStatus.OK);
+        } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().getMessage());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping(path = "", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch all flow storages", description = "Will return empty list if there are no flow storages to fetch")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FlowStorage.class))})})
+    public List<FlowStorage> getAll(@RequestParam(required = false) Integer version) {
+        return flowStorageMapper.getAll(version);
+    }
+
+    @RequestMapping(path = "/{flowId}/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Delete flow storage")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Flow storage deleted",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FlowStorage.class))}),
+            @ApiResponse(responseCode = "409", description = "Flow storage is being used",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Flow storage does not exist",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+    public ResponseEntity<String> delete(@PathVariable("flowId") int flowId, @PathVariable("id") int id) {
+        LOGGER.info("Deleting flow Storage with id <[{}]>", id);
+        try {
+            flowStorageMapper.delete(flowId, id);
+            JSONObject j = new JSONObject();
+            j.put("id", id);
+            j.put("message", "Flow storage deleted");
+            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+        } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().getMessage());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("23000")) {
+                    jsonErr.put("message", "Is in use");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
+                } else if (state.equals("45000")) {
+                    jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+}
+
+

--- a/src/main/java/com/teragrep/cfe18/handlers/StorageController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/StorageController.java
@@ -146,6 +146,7 @@ public class StorageController {
             jsonObject.put("message", "New capture storage created");
             return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
         } catch (RuntimeException ex) {
+            LOGGER.error(ex.getMessage());
             JSONObject jsonErr = new JSONObject();
             jsonErr.put("id", newCaptureStorage.getCapture_id());
             jsonErr.put("message", ex.getCause().toString());
@@ -268,7 +269,7 @@ public class StorageController {
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("23000")) {
                     jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
                 } else if (state.equals("45000")) {
                     jsonErr.put("message", "Record does not exist");
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);

--- a/src/main/java/com/teragrep/cfe18/handlers/StorageController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/StorageController.java
@@ -85,209 +85,6 @@ public class StorageController {
     @Autowired
     StorageMapper storageMapper;
 
-
-    // Fetch flow storages
-    @RequestMapping(path = "/flow/{flow}", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch flow storage by flow name")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Flow storage retrieved",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "Flow storage does not exist with the given name",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
-    public ResponseEntity<?> getStoragesByFlow(@PathVariable String flow, @RequestParam(required = false) Integer version) {
-        try {
-            List<FlowStorage> fs = storageMapper.retrieveFlowStorages(flow
-                    ,version);
-            return new ResponseEntity<>(fs, HttpStatus.OK);
-        } catch (Exception ex) {
-
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    JSONObject jsonErr = new JSONObject();
-                    jsonErr.put("message", "Record does not exist with the given flow");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // Get ALL Flow storages
-    @RequestMapping(path = "/flow", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch all flow storages", description = "Will return empty list if there are no flow storages to fetch")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Flow storages fetched",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FlowStorage.class))})
-    })
-    public List<FlowStorage> getAllFlowStorages(@RequestParam(required = false) Integer version) {
-        return storageMapper.getAllFlowStorage(version);
-    }
-
-    // Fetch capture storages
-    @RequestMapping(path = "/capture/{capture_id}", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch capture storage by capture id")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Capture storage retrieved",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CaptureStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "Capture storage does not exist with the given ID",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
-    public ResponseEntity<?> getStoragesByCaptureID(@PathVariable int capture_id, @RequestParam(required = false) Integer version) {
-        try {
-            List<CaptureStorage> cs = storageMapper.retrieveCaptureStorages(capture_id,version);
-            return new ResponseEntity<>(cs, HttpStatus.OK);
-        } catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", capture_id);
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given capture_id");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // Fetch ALL Capture storages
-    @RequestMapping(path = "/capture", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch all capture storages", description = "Will return empty list if there are no capture storages to fetch")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Capture storages fetched",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CaptureStorage.class))})
-    })
-    public List<CaptureStorage> getAllCaptureStorages(@RequestParam(required = false) Integer version) {
-        return storageMapper.getAllCaptureStorage(version);
-    }
-
-
-    @RequestMapping(path = "", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch all storages", description = "Will return empty list if there are no flow storages to fetch")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FlowStorage.class))})})
-    public List<Storage> getAll(@RequestParam(required = false) Integer version) {
-        return storageMapper.getAll(version);
-    }
-
-    @RequestMapping(path = "/{id}", method = RequestMethod.GET, produces = "application/json")
-    @Operation(summary = "Fetch storage", description = "Returns details about one storage")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Storage fetched",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = Storage.class))}),
-            @ApiResponse(responseCode = "404", description = "Storage does not exist",
-                    content = @Content)})
-    public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            Storage s = storageMapper.get(id, version);
-            return new ResponseEntity<>(s, HttpStatus.OK);
-        } catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().toString());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
-    }
-
-
-    // New storage with the flow
-    @RequestMapping(path = "/flow", method = RequestMethod.PUT, produces = "application/json")
-    @Operation(summary = "Insert new flow storage")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "New flow storage created",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "SQL Constraint error",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
-    public ResponseEntity<String> addNewStorage(@RequestBody FlowStorage newFlowStorage) {
-        LOGGER.info("About to insert <[{}]>",newFlowStorage);
-        try {
-            FlowStorage fs = storageMapper.addStorageForFlow(
-                    newFlowStorage.getFlow(),
-                    newFlowStorage.getStorage_id());
-            LOGGER.debug("Values returned <[{}]>",fs);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", fs.getId());
-            jsonObject.put("message", "New flow storage created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        } catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newFlowStorage.getId());
-            jsonErr.put("message", ex.getCause().toString());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
-    }
-
-
-    // Link storage to capture
-    @RequestMapping(path = "/capture", method = RequestMethod.PUT, produces = "application/json")
-    @Operation(summary = "Insert new capture storage")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "New capture storage created",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CaptureStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "Flow storage does not exist for linking",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
-    public ResponseEntity<String> linkStorageToCapture(@RequestBody CaptureStorage newCaptureStorage) {
-        LOGGER.info("About to insert <[{}]>",newCaptureStorage);
-        try {
-            CaptureStorage cs = storageMapper.addStorageForCapture(
-                    newCaptureStorage.getCapture_id(),
-                    newCaptureStorage.getStorage_id());
-            LOGGER.debug("Values returned <[{}]>",cs);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", cs.getCapture_id());
-            jsonObject.put("message", "New capture storage created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        } catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newCaptureStorage.getCapture_id());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                // Get specific error type
-                int error = ((SQLException) cause).getErrorCode();
-                // Link error with state to get accurate error status
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                if (state.equals("1452-23000")) {
-                    jsonErr.put("message", "Storage does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-
-        }
-    }
-
     @RequestMapping(path = "", method = RequestMethod.PUT, produces = "application/json")
     @Operation(summary = "Create storage")
     @ApiResponses(value = {
@@ -296,7 +93,8 @@ public class StorageController {
                             schema = @Schema(implementation = Storage.class))}),
             @ApiResponse(responseCode = "400", description = "Storage name already exists",
                     content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
+    })
     public ResponseEntity<String> create(@RequestBody Storage newStorage) {
         LOGGER.info("About to insert <[{}]>", newStorage);
         try {
@@ -309,7 +107,6 @@ public class StorageController {
             jsonObject.put("message", "New storage created");
             return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
         } catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
             JSONObject jsonErr = new JSONObject();
             jsonErr.put("id", newStorage.getId());
             jsonErr.put("message", ex.getCause().toString());
@@ -326,15 +123,131 @@ public class StorageController {
         }
     }
 
+
+    @RequestMapping(path = "/capture", method = RequestMethod.PUT, produces = "application/json")
+    @Operation(summary = "Create new capture storage")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "New capture storage created",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CaptureStorage.class))}),
+            @ApiResponse(responseCode = "404", description = "Flow storage does not exist",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
+    })
+    public ResponseEntity<String> createCaptureStorage(@RequestBody CaptureStorage newCaptureStorage) {
+        LOGGER.info("About to insert <[{}]>", newCaptureStorage);
+        try {
+            CaptureStorage cs = storageMapper.createCaptureStorage(
+                    newCaptureStorage.getCapture_id(),
+                    newCaptureStorage.getStorage_id());
+            LOGGER.debug("Values returned <[{}]>", cs);
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("id", cs.getCapture_id());
+            jsonObject.put("message", "New capture storage created");
+            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+        } catch (RuntimeException ex) {
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", newCaptureStorage.getCapture_id());
+            jsonErr.put("message", ex.getCause().toString());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping(path = "/{id}", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch storage", description = "Will return empty list if there are no storages to fetch")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Storage fetched",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Storage.class))}),
+            @ApiResponse(responseCode = "404", description = "Storage does not exist",
+                    content = @Content)})
+    public ResponseEntity<?> getStorage(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
+        try {
+            Storage s = storageMapper.getStorage(id, version);
+            return new ResponseEntity<>(s, HttpStatus.OK);
+        } catch (Exception ex) {
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().toString());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+
+    @RequestMapping(path = "/capture/{captureId}", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch capture storage")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Capture storage retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CaptureStorage.class))}),
+            @ApiResponse(responseCode = "400", description = "Capture storage does not exist with the given ID",
+                    content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
+    public ResponseEntity<?> getCaptureStorage(@PathVariable("captureId") int captureId, @RequestParam(required = false) Integer version) {
+        try {
+            List<CaptureStorage> cs = storageMapper.getCaptureStorage(captureId, version);
+            return new ResponseEntity<>(cs, HttpStatus.OK);
+        } catch (RuntimeException ex) {
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", captureId);
+            jsonErr.put("message", ex.getCause().getMessage());
+            final Throwable cause = ex.getCause();
+            if (cause instanceof SQLException) {
+                LOGGER.error((cause).getMessage());
+                String state = ((SQLException) cause).getSQLState();
+                if (state.equals("45000")) {
+                    jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
+                }
+            }
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping(path = "", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch all storages", description = "Will return empty list if there are no flow storages to fetch")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = FlowStorage.class))})})
+    public List<Storage> getAll(@RequestParam(required = false) Integer version) {
+        return storageMapper.getAll(version);
+    }
+
+    @RequestMapping(path = "/capture", method = RequestMethod.GET, produces = "application/json")
+    @Operation(summary = "Fetch all capture storages", description = "Will return empty list if there are no capture storages to fetch")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CaptureStorage.class))})})
+    public List<CaptureStorage> getAllCapture(@RequestParam(required = false) Integer version) {
+        return storageMapper.getAllCapture(version);
+    }
+
     @RequestMapping(path = "/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Delete storage")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Storage deleted",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = Storage.class))}),
-            @ApiResponse(responseCode = "404", description = "Storage does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "409", description = "Storage is being used",
+            @ApiResponse(responseCode = "400", description = "Storage is being used OR Storage does not exist",
                     content = @Content),
             @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)})
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
@@ -346,7 +259,6 @@ public class StorageController {
             j.put("message", "Storage deleted");
             return new ResponseEntity<>(j.toString(), HttpStatus.OK);
         } catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
             JSONObject jsonErr = new JSONObject();
             jsonErr.put("id", id);
             jsonErr.put("message", ex.getCause().getMessage());
@@ -356,7 +268,7 @@ public class StorageController {
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("23000")) {
                     jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
                 } else if (state.equals("45000")) {
                     jsonErr.put("message", "Record does not exist");
                     return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
@@ -366,45 +278,7 @@ public class StorageController {
         }
     }
 
-    // Delete flow storage
-    @RequestMapping(path = "/flow/{flow}/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "Delete flow storage")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Flow storage deleted",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = FlowStorage.class))}),
-            @ApiResponse(responseCode = "400", description = "Flow storage is being used OR Flow storage does not exist",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
-    })
-    public ResponseEntity<String> removeFlowStorage(@PathVariable("flow") String flow, @PathVariable("id") int id) {
-        LOGGER.info("Deleting flow Storage with id <[{}]>", id);
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", id);
-        try {
-            storageMapper.deleteFlowStorage(flow, id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Flow =" + flow + ", Storage " + id + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        } catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                } else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // Delete capture storage
-    @RequestMapping(path = "/capture/{capture_id}/{storage_id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(path = "/capture/{captureId}/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Delete capture storage")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Capture storage deleted",
@@ -414,29 +288,33 @@ public class StorageController {
                     content = @Content),
             @ApiResponse(responseCode = "500", description = "Internal server error, contact admin", content = @Content)
     })
-    public ResponseEntity<String> removeCaptureStorage(@PathVariable("capture_id") int capture_id, @PathVariable("storage_id") int storage_id) {
-        LOGGER.info("Deleting capture storage with id <[{}]>",storage_id);
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", capture_id);
+    public ResponseEntity<String> deleteCaptureStorage(@PathVariable("captureId") int captureId, @PathVariable("id") int id) {
+        LOGGER.info("Deleting capture storage with id <[{}]>", id);
         try {
-            storageMapper.deleteCaptureStorage(capture_id, storage_id);
+            storageMapper.deleteCaptureStorage(captureId, id);
             JSONObject j = new JSONObject();
-            j.put("id", capture_id);
-            j.put("message", "Capture = " + capture_id + ", with Storage " + storage_id + " deleted.");
+            j.put("id", id);
+            j.put("message", "Capture storage deleted");
             return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
+            JSONObject jsonErr = new JSONObject();
+            jsonErr.put("id", id);
+            jsonErr.put("message", ex.getCause().getMessage());
             final Throwable cause = ex.getCause();
             if (cause instanceof SQLException) {
                 LOGGER.error((cause).getMessage());
                 String state = ((SQLException) cause).getSQLState();
                 if (state.equals("23000")) {
                     jsonErr.put("message", "Is in use");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
                 } else if (state.equals("45000")) {
                     jsonErr.put("message", "Record does not exist");
+                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
                 }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
             }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 }
+
+

--- a/src/main/java/com/teragrep/cfe18/handlers/entities/FlowStorage.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/entities/FlowStorage.java
@@ -52,22 +52,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class FlowStorage {
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private int id;
+    private int flowId;
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
-    private String storage_type;
-
-    private String flow;
+    private Storage.StorageType storageType;
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
-    private String storage_name;
-
-    private int storage_id;
-
-    public int getStorage_id() {
-        return storage_id;
-    }
-
-    public void setStorage_id(int storage_id) {
-        this.storage_id = storage_id;
-    }
+    private String storageName;
+    private int storageId;
 
     public int getId() {
         return id;
@@ -77,38 +67,46 @@ public class FlowStorage {
         this.id = id;
     }
 
-    public String getStorage_type() {
-        return storage_type;
+    public int getFlowId() {
+        return flowId;
     }
 
-    public void setStorage_type(String storage_type) {
-        this.storage_type = storage_type;
+    public void setFlowId(int flowId) {
+        this.flowId = flowId;
     }
 
-    public String getFlow() {
-        return flow;
+    public Storage.StorageType getStorageType() {
+        return storageType;
     }
 
-    public void setFlow(String flow) {
-        this.flow = flow;
+    public void setStorageType(Storage.StorageType storageType) {
+        this.storageType = storageType;
     }
 
-    public String getStorage_name() {
-        return storage_name;
+    public String getStorageName() {
+        return storageName;
     }
 
-    public void setStorage_name(String storage_name) {
-        this.storage_name = storage_name;
+    public void setStorageName(String storageName) {
+        this.storageName = storageName;
+    }
+
+    public int getStorageId() {
+        return storageId;
+    }
+
+    public void setStorageId(int storageId) {
+        this.storageId = storageId;
     }
 
     @Override
     public String toString() {
         return "FlowStorage{" +
                 "id=" + id +
-                ", storage_type='" + storage_type + '\'' +
-                ", flow='" + flow + '\'' +
-                ", storage_name='" + storage_name + '\'' +
-                ", storage_id=" + storage_id +
+                ", flowId=" + flowId +
+                ", storageType='" + storageType + '\'' +
+                ", storageName='" + storageName + '\'' +
+                ", storageId=" + storageId +
                 '}';
     }
 }

--- a/src/main/resources/com/teragrep/cfe18/FlowStorageMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/FlowStorageMapper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.teragrep.cfe18.FlowStorageMapper">
+
+    <!-- insert         ( p_flow_id INT, proc_storage_id INT ) -->
+    <select id="create" resultMap="insertedID" statementType="CALLABLE">
+        {CALL flow.insert_flow_storage(#{param1},#{param2})}
+    </select>
+
+
+    <!-- get            ( flow_id INT, tx_id INT ) -->
+    <select id="get" resultMap="flowStorages" statementType="CALLABLE">
+        {CALL flow.select_flow_storages(#{param1},#{param2})}
+    </select>
+    <resultMap id="flowStorages" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
+        <result property="id"           column="id"/>
+        <result property="flowId"       column="flow_id"/>
+        <result property="storageId"    column="storage_id"/>
+        <result property="storageName"  column="storage_name"/>
+        <result property="storageType"  column="storage_type"/>
+    </resultMap>
+
+
+    <!-- GET ALL        ( tx_id INT ) -->
+    <select id="getAll" resultMap="allFlowStorages" statementType="CALLABLE">
+        {CALL flow.select_all_flow_storages(#{param1})}
+    </select>
+    <resultMap id="allFlowStorages" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
+        <result property="id"           column="id"/>
+        <result property="flowId"       column="flow_id"/>
+        <result property="storageId"    column="storage_id"/>
+        <result property="storageName"  column="storage_name"/>
+        <result property="storageType"  column="storage_type"/>
+    </resultMap>
+
+
+    <!-- Delete         ( proc_flow_id INT, proc_storage_id INT ) -->
+    <select id="delete" statementType="CALLABLE">
+        {CALL flow.delete_flow_storage(#{param1},#{param2})}
+    </select>
+
+
+    <!-- ID return map -->
+    <resultMap id="insertedID" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
+        <result property="id"       column="id"/>
+    </resultMap>
+
+
+</mapper>

--- a/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
@@ -30,10 +30,10 @@
 
     <!-- get            ( capture_id INT, tx_id INT ) -->
     <select id="getCaptureStorage" resultMap="captureStorage" statementType="CALLABLE">
-        {CALL cfe_18.select_capture_storages(#{param1},#{param2})}
+        {CALL cfe_18.retrieve_capture_storages(#{param1},#{param2})}
     </select>
     <resultMap id="captureStorage" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="capture_d"    column="capture_id"/>
+        <result property="capture_id"    column="capture_id"/>
         <result property="storage_id"    column="storage_id"/>
         <result property="storage_name"  column="storage_name"/>
     </resultMap>
@@ -53,7 +53,7 @@
 
     <!-- GET ALL        ( tx_id INT ) -->
     <select id="getAllCapture" resultMap="allCaptureStorages" statementType="CALLABLE">
-        {CALL cfe_18.select_all_capture_storages(#{param2})}
+        {CALL cfe_18.retrieve_all_capture_storages(#{param1})}
     </select>
     <resultMap id="allCaptureStorages" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
         <result property="capture_id"    column="capture_id"/>
@@ -70,7 +70,7 @@
 
     <!-- Delete         ( capture_id INT, proc_storage_id INT ) -->
     <select id="deleteCaptureStorage" statementType="CALLABLE">
-        {CALL cfe_18.delete_capture_storage(#{param1},#{param2})}
+        {CALL cfe_18.remove_capture_storage(#{param1},#{param2})}
     </select>
 
 
@@ -81,7 +81,7 @@
 
     <!-- ID return map -->
     <resultMap id="insertedIDCapture" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="capture_id"       column="id"/>
+        <result property="capture_id"       column="last"/>
     </resultMap>
 
 </mapper>

--- a/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
@@ -33,9 +33,9 @@
         {CALL cfe_18.select_capture_storages(#{param1},#{param2})}
     </select>
     <resultMap id="captureStorage" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="captureId"    column="capture_id"/>
-        <result property="storageId"    column="storage_id"/>
-        <result property="storageName"  column="storage_name"/>
+        <result property="capture_d"    column="capture_id"/>
+        <result property="storage_id"    column="storage_id"/>
+        <result property="storage_name"  column="storage_name"/>
     </resultMap>
 
 
@@ -56,9 +56,9 @@
         {CALL cfe_18.select_all_capture_storages(#{param2})}
     </select>
     <resultMap id="allCaptureStorages" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="captureId"    column="capture_id"/>
-        <result property="storageId"    column="storage_id"/>
-        <result property="storageName"  column="storage_name"/>
+        <result property="capture_id"    column="capture_id"/>
+        <result property="storage_id"    column="storage_id"/>
+        <result property="storage_name"  column="storage_name"/>
     </resultMap>
 
 
@@ -81,7 +81,7 @@
 
     <!-- ID return map -->
     <resultMap id="insertedIDCapture" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="captureId"       column="id"/>
+        <result property="capture_id"       column="id"/>
     </resultMap>
 
 </mapper>

--- a/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/StorageMapper.xml
@@ -4,20 +4,38 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.teragrep.cfe18.StorageMapper">
 
+
     <!-- insert         ( proc_cfe_type VARCHAR(6), proc_storage_name VARCHAR(255) )-->
     <select id="create" resultMap="insertedID" statementType="CALLABLE">
         {CALL flow.insert_storage(#{param1},#{param2})}
     </select>
 
 
+    <!-- insert         ( capture_id INT, storage_id INT ) -->
+    <select id="createCaptureStorage" resultMap="insertedIDCapture" statementType="CALLABLE">
+        {CALL flow.add_storage_for_capture(#{param1},#{param2})}
+    </select>
+
+
     <!-- get            ( storage_id INT, tx_id INT ) -->
-    <select id="get" resultMap="storage" statementType="CALLABLE">
+    <select id="getStorage" resultMap="storage" statementType="CALLABLE">
         {CALL flow.select_storage(#{param1},#{param2})}
     </select>
     <resultMap id="storage" type="com.teragrep.cfe18.handlers.entities.Storage">
         <result property="id"           column="id"/>
         <result property="storageName"  column="storage_name"/>
         <result property="storageType"      column="storage_type"/>
+    </resultMap>
+
+
+    <!-- get            ( capture_id INT, tx_id INT ) -->
+    <select id="getCaptureStorage" resultMap="captureStorage" statementType="CALLABLE">
+        {CALL cfe_18.select_capture_storages(#{param1},#{param2})}
+    </select>
+    <resultMap id="captureStorage" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
+        <result property="captureId"    column="capture_id"/>
+        <result property="storageId"    column="storage_id"/>
+        <result property="storageName"  column="storage_name"/>
     </resultMap>
 
 
@@ -32,89 +50,38 @@
     </resultMap>
 
 
+
+    <!-- GET ALL        ( tx_id INT ) -->
+    <select id="getAllCapture" resultMap="allCaptureStorages" statementType="CALLABLE">
+        {CALL cfe_18.select_all_capture_storages(#{param2})}
+    </select>
+    <resultMap id="allCaptureStorages" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
+        <result property="captureId"    column="capture_id"/>
+        <result property="storageId"    column="storage_id"/>
+        <result property="storageName"  column="storage_name"/>
+    </resultMap>
+
+
     <!-- Delete         ( proc_storage_id INT ) -->
     <select id="delete" statementType="CALLABLE">
         {CALL flow.delete_storage(#{param1})}
     </select>
 
-    <!-- ADD storage for flow -->
-    <select id="addStorageForFlow" resultMap="insertedFlowStorage" statementType="CALLABLE">
-        {CALL flow.add_storage(#{param1},#{param2})}
-    </select>
-    <resultMap id="insertedFlowStorage" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
-        <result property="id" column="last"/>
-    </resultMap>
 
-
-    <!-- ADD storage for capture -->
-    <select id="addStorageForCapture" resultMap="linkedStorage" statementType="CALLABLE">
-        {CALL flow.add_storage_for_capture(#{param1},#{param2})}
-    </select>
-    <resultMap id="linkedStorage" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="capture_id" column="last"/>
-    </resultMap>
-
-
-    <!-- get flow storages -->
-    <select id="retrieveFlowStorages" resultMap="flowTargets" statementType="CALLABLE">
-        {CALL flow.retrieve_flow_storages(#{param1},#{param2})}
-    </select>
-    <resultMap id="flowTargets" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
-        <result property="storage_name" column="target"/>
-        <result property="flow" column="flow"/>
-        <result property="storage_type" column="storage_type"/>
-        <result property="id" column="last"/>
-        <result property="storage_id" column="storage_id"/>
-    </resultMap>
-
-
-    <!-- get ALL capture storages -->
-    <select id="retrieveCaptureStorages" resultMap="captureTargets" statementType="CALLABLE">
-        {CALL cfe_18.retrieve_capture_storages(#{param1},#{param2})}
-    </select>
-    <resultMap id="captureTargets" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="storage_name" column="storage_name"/>
-        <result property="storage_id" column="storage_id"/>
-        <result property="capture_id" column="capture_id"/>
-    </resultMap>
-
-
-
-
-
-    <!-- Get ALL Capture Storages -->
-    <select id="getAllCaptureStorage" resultMap="allCaptureStorage" statementType="CALLABLE">
-        {CALL cfe_18.retrieve_all_capture_storages(#{param1})}
-    </select>
-    <resultMap id="allCaptureStorage" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
-        <result property="capture_id" column="capture_id"/>
-        <result property="storage_id" column="storage_id"/>
-        <result property="storage_name" column="storage_name"/>
-    </resultMap>
-
-
-    <!-- Get ALL Flow Storages -->
-    <select id="getAllFlowStorage" resultMap="allFlowStorage" statementType="CALLABLE">
-        {CALL flow.retrieve_all_flow_storages(#{param1})}
-    </select>
-    <resultMap id="allFlowStorage" type="com.teragrep.cfe18.handlers.entities.FlowStorage">
-        <result property="id" column="id"/>
-        <result property="flow" column="flow"/>
-        <result property="storage_name" column="storage_name"/>
-        <result property="storage_type" column="storage_type"/>
-        <result property="storage_id" column="storage_id"/>
-    </resultMap>
-
-    <select id="deleteFlowStorage" statementType="CALLABLE">
-        {CALL flow.remove_flow_storage(#{param1},#{param2})}
-    </select>
-
+    <!-- Delete         ( capture_id INT, proc_storage_id INT ) -->
     <select id="deleteCaptureStorage" statementType="CALLABLE">
-        {CALL cfe_18.remove_capture_storage(#{param1},#{param2})}
+        {CALL cfe_18.delete_capture_storage(#{param1},#{param2})}
     </select>
+
 
     <!-- ID return map -->
     <resultMap id="insertedID" type="com.teragrep.cfe18.handlers.entities.Storage">
         <result property="id"       column="id"/>
     </resultMap>
+
+    <!-- ID return map -->
+    <resultMap id="insertedIDCapture" type="com.teragrep.cfe18.handlers.entities.CaptureStorage">
+        <result property="captureId"       column="id"/>
+    </resultMap>
+
 </mapper>

--- a/src/main/resources/db/migration/R__Procedure_Select_Flow_Storages.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Flow_Storages.sql
@@ -43,9 +43,9 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-use flow;
+USE flow;
 DELIMITER //
-CREATE OR REPLACE PROCEDURE remove_flow_storage(proc_flow varchar(255), proc_storage_id int)
+CREATE OR REPLACE PROCEDURE select_flow_storages(flow_id INT, tx_id INT)
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION
         BEGIN
@@ -53,12 +53,25 @@ BEGIN
             RESIGNAL;
         END;
     START TRANSACTION;
-    select id into @FlowId from flow.flows where name = proc_flow;
-    if (select id from flow.flow_targets where flow_id = @FlowId and storage_id = proc_storage_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Flow storage does not exist') into @fs;
-        signal sqlstate '45000' set message_text = @fs;
-    end if;
-    delete from flow.flow_targets where storage_id = proc_storage_id and flow_id = @FlowId;
+    IF (tx_id) IS NULL THEN
+        SET @time = (SELECT MAX(transaction_id) FROM mysql.transaction_registry);
+    ELSE
+        SET @time = tx_id;
+    END IF;
+    IF ((SELECT COUNT(id) FROM flows FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = flow_id) = 0) THEN
+        SELECT JSON_OBJECT('id', flow_id, 'message', 'Flow does not exist') INTO @fs;
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @fs;
+    ELSE
+        SELECT ft.id           AS id,
+               f.id            AS flow_id,
+               s.id            AS storage_id,
+               s.storage_name  AS storage_name,
+               ft.storage_type AS storage_type
+        FROM flow.flow_targets FOR SYSTEM_TIME AS OF TRANSACTION @time ft
+                 INNER JOIN flows FOR SYSTEM_TIME AS OF TRANSACTION @time f ON ft.flow_id = f.id
+                 LEFT JOIN storages FOR SYSTEM_TIME AS OF TRANSACTION @time s ON ft.storage_id = s.id
+        WHERE f.id = flow_id;
+    END IF;
     COMMIT;
 END;
 //

--- a/src/test/java/com/teragrep/cfe18/controllerTests/FlowStorageControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/FlowStorageControllerTest.java
@@ -1,0 +1,484 @@
+/*
+ * Integration main data management for Teragrep
+ * Copyright (C) 2021  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cfe18.controllerTests;
+
+import com.google.gson.Gson;
+import com.teragrep.cfe18.handlers.entities.*;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(MigrateDatabaseExtension.class)
+public class FlowStorageControllerTest extends TestSpringBootInformation {
+
+    Gson gson = new Gson();
+
+    @LocalServerPort
+    private int port;
+
+
+    @Test
+    @Order(1)
+    public void testData() {
+
+        Flow flow = new Flow();
+        flow.setName("Testflow");
+
+        String json = gson.toJson(flow);
+
+        // forms the json to requestEntity
+        StringEntity requestEntity = new StringEntity(
+                String.valueOf(json),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut request = new HttpPut("http://localhost:" + port + "/flow");
+        // set requestEntity to the put request
+        request.setEntity(requestEntity);
+        // Header
+        request.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponseFlow = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
+
+        // Get the entity from response
+        HttpEntity entityFlow = httpResponseFlow.getEntity();
+
+        // Entity response string
+        String responseStringFlow = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityFlow));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJsonFlow = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringFlow));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expectedFlow = "New flow created";
+
+        // Creating string from Json that was given as a response
+        String actualFlow = Assertions.assertDoesNotThrow(() -> responseAsJsonFlow.get("message").toString());
+
+
+        Storage storage = new Storage();
+        storage.setStorageType(Storage.StorageType.cfe_04);
+        storage.setStorageName("cfe_04");
+
+        String jsonStorage = gson.toJson(storage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorage = new StringEntity(
+                String.valueOf(jsonStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestStorage = new HttpPut("http://localhost:" + port + "/storage");
+        // set requestEntity to the put request
+        requestStorage.setEntity(requestEntityStorage);
+        // Header
+        requestStorage.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponseStorage = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestStorage));
+
+        // Get the entity from response
+        HttpEntity entityStorage = httpResponseStorage.getEntity();
+
+        // Entity response string
+        String responseStringStorage = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityStorage));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJsonStorage = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringStorage));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expectedStorage = "New storage created";
+
+        // Creating string from Json that was given as a response
+        String actualStorage = Assertions.assertDoesNotThrow(() -> responseAsJsonStorage.get("message").toString());
+
+
+        // Assertions
+        assertEquals(expectedFlow, actualFlow);
+        assertThat(
+                httpResponseStorage.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+        // Assertions
+        assertEquals(expectedStorage, actualStorage);
+        assertThat(
+                httpResponseStorage.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+
+
+    }
+
+    @Test
+    @Order(2)
+    public void testInsertFlowStorage() {
+
+        FlowStorage flowStorage = new FlowStorage();
+        flowStorage.setFlowId(1);
+        flowStorage.setStorageId(1);
+
+        String jsonStorage = gson.toJson(flowStorage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorageFlow = new StringEntity(
+                String.valueOf(jsonStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestEntityStorage = new HttpPut("http://localhost:" + port + "/storage/flow");
+        // set requestEntity to the put request
+        requestEntityStorage.setEntity(requestEntityStorageFlow);
+        // Header
+        requestEntityStorage.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestEntityStorage));
+
+        // Get the entity from response
+        HttpEntity entity = httpResponse.getEntity();
+
+        // Entity response string
+        String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expected = "New flow storage created";
+
+        // Creating string from Json that was given as a response
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
+
+        // Assertions
+
+        assertEquals(expected, actual);
+        assertThat(
+                httpResponse.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+    }
+
+    @Test
+    @Order(3)
+    public void testFetchFlowStorage() {
+        ArrayList<FlowStorage> expected = new ArrayList<>();
+
+        FlowStorage flowStorage = new FlowStorage();
+        flowStorage.setId(1);
+        flowStorage.setFlowId(1);
+        flowStorage.setStorageType(Storage.StorageType.cfe_04);
+        flowStorage.setStorageName("cfe_04");
+        flowStorage.setStorageId(1);
+
+        expected.add(flowStorage);
+
+        // Asserting get request
+        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/storage/flow/1");
+
+        requestGet.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse responseGet = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestGet));
+
+        HttpEntity entityGet = responseGet.getEntity();
+
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
+
+        String expectedJson = new Gson().toJson(expected);
+
+        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertEquals(expectedJson, responseStringGet);
+    }
+
+    @Test
+    @Order(4)
+    public void testFetchFlowStorages() {
+
+        ArrayList<FlowStorage> expected = new ArrayList<>();
+
+        FlowStorage flowStorage = new FlowStorage();
+        flowStorage.setId(1);
+        flowStorage.setFlowId(1);
+        flowStorage.setStorageName("cfe_04");
+        flowStorage.setStorageType(Storage.StorageType.cfe_04);
+        flowStorage.setStorageId(1);
+
+        expected.add(flowStorage);
+
+        // Asserting get request
+        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/storage/flow");
+
+        requestGet.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse responseGet = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestGet));
+
+        HttpEntity entityGet = responseGet.getEntity();
+
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
+
+        String expectedJson = new Gson().toJson(expected);
+
+        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertEquals(expectedJson, responseStringGet);
+    }
+
+    @Test
+    @Order(5)
+    public void testDeleteNonExistentFlowStorage() {
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/1/124");
+
+        // Header
+        delete.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
+
+        HttpEntity entityDelete = deleteResponse.getEntity();
+
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGet));
+
+        // Creating string from Json that was given as a response
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expected = "Record does not exist";
+        assertEquals(expected, actual);
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
+    }
+
+    @Test
+    @Order(6)
+    public void testDeleteFlowStorageInUse() {
+
+        Sink sink = new Sink();
+        sink.setFlow("Testflow");
+        sink.setPort("cap");
+        sink.setIp_address("capsink");
+        sink.setProtocol("prot");
+
+        String json1 = gson.toJson(sink);
+
+        // forms the json to requestEntity
+        StringEntity requestEntity1 = new StringEntity(
+                String.valueOf(json1),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut request1 = new HttpPut("http://localhost:" + port + "/sink/details");
+        // set requestEntity to the put request
+        request1.setEntity(requestEntity1);
+        // Header
+        request1.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request1));
+
+
+        // add relp type capture with the same flow
+        CaptureRelp captureRelp = new CaptureRelp();
+        captureRelp.setTag("relpTag");
+        captureRelp.setRetentionTime("P30D");
+        captureRelp.setCategory("audit");
+        captureRelp.setApplication("relp");
+        captureRelp.setIndex("audit_relp");
+        captureRelp.setSourceType("relpsource1");
+        captureRelp.setProtocol("prot");
+        captureRelp.setFlow("Testflow");
+
+        String jsonFile = gson.toJson(captureRelp);
+
+        // forms the json to requestEntity
+        StringEntity requestEntity3 = new StringEntity(
+                String.valueOf(jsonFile),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut request3 = new HttpPut("http://localhost:" + port + "/capture/relp");
+        // set requestEntity to the put request
+        request3.setEntity(requestEntity3);
+        // Header
+        request3.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request3));
+
+        CaptureStorage captureStorage = new CaptureStorage();
+        captureStorage.setCapture_id(1);
+        captureStorage.setStorage_id(1);
+
+        String jsonStorage = gson.toJson(captureStorage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorageCapture = new StringEntity(
+                String.valueOf(jsonStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestEntityCaptureStorage = new HttpPut("http://localhost:" + port + "/storage/capture");
+        // set requestEntity to the put request
+        requestEntityCaptureStorage.setEntity(requestEntityStorageCapture);
+        // Header
+        requestEntityCaptureStorage.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponseCaptureStorage = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestEntityCaptureStorage));
+
+        // Get the entity from response
+        HttpEntity entityCaptureStorage = httpResponseCaptureStorage.getEntity();
+
+        Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityCaptureStorage));
+
+        // Assertions
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/1/1");
+
+        // Header
+        delete.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
+
+        HttpEntity entityDelete = deleteResponse.getEntity();
+
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGet));
+
+        // Creating string from Json that was given as a response
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expected = "Is in use";
+
+        assertEquals(expected, actual);
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+    }
+
+    @Test
+    @Order(7)
+    public void testDeleteFlowStorage() {
+        Storage storage = new Storage();
+        storage.setStorageType(Storage.StorageType.cfe_11);
+        storage.setStorageName("cfe_11");
+
+        String jsonStorage = gson.toJson(storage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorage = new StringEntity(
+                String.valueOf(jsonStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestStorage = new HttpPut("http://localhost:" + port + "/storage");
+        // set requestEntity to the put request
+        requestStorage.setEntity(requestEntityStorage);
+        // Header
+        requestStorage.setHeader("Authorization", "Bearer " + token);
+
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestStorage));
+
+        FlowStorage flowStorage = new FlowStorage();
+        flowStorage.setFlowId(1);
+        flowStorage.setStorageId(2);
+
+        String jsonFlowStorage = gson.toJson(flowStorage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorageFlow = new StringEntity(
+                String.valueOf(jsonFlowStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestEntityFlowStorage = new HttpPut("http://localhost:" + port + "/storage/flow");
+        // set requestEntity to the put request
+        requestEntityFlowStorage.setEntity(requestEntityStorageFlow);
+        // Header
+        requestEntityFlowStorage.setHeader("Authorization", "Bearer " + token);
+
+        Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestEntityFlowStorage));
+
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/1/2");
+        // Header
+        delete.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse deleteResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(delete));
+
+        HttpEntity entityDelete = deleteResponse.getEntity();
+
+        String responseStringGetFlowStorage = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityDelete, "UTF-8"));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJsonFlowStorage = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringGetFlowStorage));
+
+        // Creating string from Json that was given as a response
+        String actualFlowStorage = Assertions.assertDoesNotThrow(() -> responseAsJsonFlowStorage.get("message").toString());
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expectedFlowStorage = "Flow storage deleted";
+
+
+        assertEquals(actualFlowStorage, expectedFlowStorage);
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+    }
+}

--- a/src/test/java/com/teragrep/cfe18/controllerTests/FlowStorageControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/FlowStorageControllerTest.java
@@ -65,8 +65,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 
 import java.util.ArrayList;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -84,7 +82,6 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
     @Test
     @Order(1)
     public void testData() {
-
         Flow flow = new Flow();
         flow.setName("Testflow");
 
@@ -160,14 +157,10 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
 
         // Assertions
         assertEquals(expectedFlow, actualFlow);
-        assertThat(
-                httpResponseStorage.getStatusLine().getStatusCode(),
-                equalTo(HttpStatus.SC_CREATED));
+        assertEquals(HttpStatus.SC_CREATED, httpResponseFlow.getStatusLine().getStatusCode());
         // Assertions
         assertEquals(expectedStorage, actualStorage);
-        assertThat(
-                httpResponseStorage.getStatusLine().getStatusCode(),
-                equalTo(HttpStatus.SC_CREATED));
+        assertEquals(HttpStatus.SC_CREATED, httpResponseStorage.getStatusLine().getStatusCode());
 
 
     }
@@ -215,9 +208,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
         // Assertions
 
         assertEquals(expected, actual);
-        assertThat(
-                httpResponse.getStatusLine().getStatusCode(),
-                equalTo(HttpStatus.SC_CREATED));
+        assertEquals(HttpStatus.SC_CREATED, httpResponse.getStatusLine().getStatusCode());
     }
 
     @Test
@@ -245,9 +236,9 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
 
         String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
 
-        String expectedJson = new Gson().toJson(expected);
+        String expectedJson = gson.toJson(expected);
 
-        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertEquals(HttpStatus.SC_OK, responseGet.getStatusLine().getStatusCode());
         assertEquals(expectedJson, responseStringGet);
     }
 
@@ -279,7 +270,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
 
         String expectedJson = new Gson().toJson(expected);
 
-        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertEquals(HttpStatus.SC_OK, responseGet.getStatusLine().getStatusCode());
         assertEquals(expectedJson, responseStringGet);
     }
 
@@ -306,7 +297,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
+        assertEquals(HttpStatus.SC_NOT_FOUND, deleteResponse.getStatusLine().getStatusCode());
     }
 
     @Test
@@ -314,9 +305,9 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
     public void testDeleteFlowStorageInUse() {
 
         Sink sink = new Sink();
-        sink.setFlow("Testflow");
+        sink.setFlowId(1);
         sink.setPort("cap");
-        sink.setIp_address("capsink");
+        sink.setIpAddress("capsink");
         sink.setProtocol("prot");
 
         String json1 = gson.toJson(sink);
@@ -327,7 +318,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
                 ContentType.APPLICATION_JSON);
 
         // Creates the request
-        HttpPut request1 = new HttpPut("http://localhost:" + port + "/sink/details");
+        HttpPut request1 = new HttpPut("http://localhost:" + port + "/sink");
         // set requestEntity to the put request
         request1.setEntity(requestEntity1);
         // Header
@@ -412,7 +403,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
         String expected = "Is in use";
 
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertEquals(HttpStatus.SC_CONFLICT, deleteResponse.getStatusLine().getStatusCode());
     }
 
     @Test
@@ -477,8 +468,7 @@ public class FlowStorageControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expectedFlowStorage = "Flow storage deleted";
 
-
-        assertEquals(actualFlowStorage, expectedFlowStorage);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertEquals(expectedFlowStorage, actualFlowStorage);
+        assertEquals(HttpStatus.SC_OK, deleteResponse.getStatusLine().getStatusCode());
     }
 }

--- a/src/test/java/com/teragrep/cfe18/controllerTests/StorageControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/StorageControllerTest.java
@@ -80,6 +80,134 @@ public class StorageControllerTest extends TestSpringBootInformation {
     @LocalServerPort
     private int port;
 
+    @Test
+    @Order(1)
+    public void testData() {
+        Storage storage = new Storage();
+        storage.setStorageType(Storage.StorageType.cfe_04);
+        storage.setStorageName("cfe_04");
+
+        String json = gson.toJson(storage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntity = new StringEntity(
+                String.valueOf(json),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut request = new HttpPut("http://localhost:" + port + "/storage");
+        // set requestEntity to the put request
+        request.setEntity(requestEntity);
+        // Header
+        request.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponse = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
+
+        // Get the entity from response
+        HttpEntity entity = httpResponse.getEntity();
+
+        // Entity response string
+        String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity));
+
+        // Parsing response as JSONObject
+        JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expected = "New storage created";
+
+        // Creating string from Json that was given as a response
+        String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
+
+
+        Flow flow = new Flow();
+        flow.setName("Testflow");
+
+        String jsonFlow = gson.toJson(flow);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityFlow = new StringEntity(
+                String.valueOf(jsonFlow),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestFlow = new HttpPut("http://localhost:" + port + "/flow");
+        // set requestEntity to the put request
+        requestFlow.setEntity(requestEntityFlow);
+        // Header
+        requestFlow.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+           HttpResponse httpResponseFlow = Assertions.assertDoesNotThrow(() ->HttpClientBuilder.create().build().execute(requestFlow));
+        // Get the entity from response
+        HttpEntity entityFlow = httpResponseFlow.getEntity();
+
+        // Entity response string
+        String responseStringFlow = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityFlow));
+
+        // Parsin respponse as JSONObject
+        JSONObject responseAsJsonFlow = Assertions.assertDoesNotThrow(() -> new JSONObject(responseStringFlow));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expectedFlow = "New flow created";
+
+        // Creating string from Json that was given as a response
+        String actualFlow = Assertions.assertDoesNotThrow(() -> responseAsJsonFlow.get("message").toString());
+
+        FlowStorage flowStorage = new FlowStorage();
+        flowStorage.setFlowId(1);
+        flowStorage.setStorageId(1);
+
+        String jsonStorage = gson.toJson(flowStorage);
+
+        // forms the json to requestEntity
+        StringEntity requestEntityStorageFlow = new StringEntity(
+                String.valueOf(jsonStorage),
+                ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut requestEntityFlowStorage = new HttpPut("http://localhost:" + port + "/storage/flow");
+        // set requestEntity to the put request
+        requestEntityFlowStorage.setEntity(requestEntityStorageFlow);
+        // Header
+        requestEntityFlowStorage.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse httpResponse2 = Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestEntityFlowStorage));
+
+        // Get the entity from response
+        HttpEntity entity2 = httpResponse2.getEntity();
+
+        // Entity response string
+        String responseString2 = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity2));
+
+        // Parsin respponse as JSONObject
+        JSONObject responseAsJson2 = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString2));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expected2 = "New flow storage created";
+
+        // Creating string from Json that was given as a response
+        String actual2 = Assertions.assertDoesNotThrow(() -> responseAsJson2.get("message").toString());
+
+        // Assertions
+        assertEquals(expected, actual);
+        assertThat(
+                httpResponse.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+
+        // Assertions
+        assertEquals(expectedFlow, actualFlow);
+        assertThat(
+                httpResponse.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+
+        // Assertions
+        assertEquals(expected2, actual2);
+        assertThat(
+                httpResponse.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_CREATED));
+    }
 
     @Test
     @Order(1)
@@ -186,142 +314,8 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(3)
-    public void testInsertFlowStorage() throws Exception {
-
-        Flow flow = new Flow();
-        flow.setName("Testflow");
-
-        String json = gson.toJson(flow);
-
-        // forms the json to requestEntity
-        StringEntity requestEntity = new StringEntity(
-                String.valueOf(json),
-                ContentType.APPLICATION_JSON);
-
-        // Creates the request
-        HttpPut request = new HttpPut("http://localhost:" + port + "/flow");
-        // set requestEntity to the put request
-        request.setEntity(requestEntity);
-        // Header
-        request.setHeader("Authorization", "Bearer " + token);
-
-        // Get the response from endpoint
-        HttpClientBuilder.create().build().execute(request);
-
-
-        FlowStorage flowStorage = new FlowStorage();
-        flowStorage.setFlow("Testflow");
-        flowStorage.setStorage_id(1);
-
-        String jsonStorage = gson.toJson(flowStorage);
-
-        // forms the json to requestEntity
-        StringEntity requestEntityStorageFlow = new StringEntity(
-                String.valueOf(jsonStorage),
-                ContentType.APPLICATION_JSON);
-
-        // Creates the request
-        HttpPut requestEntityStorage = new HttpPut("http://localhost:" + port + "/storage/flow");
-        // set requestEntity to the put request
-        requestEntityStorage.setEntity(requestEntityStorageFlow);
-        // Header
-        requestEntityStorage.setHeader("Authorization", "Bearer " + token);
-
-        // Get the response from endpoint
-        HttpResponse httpResponse = HttpClientBuilder.create().build().execute(requestEntityStorage);
-
-        // Get the entity from response
-        HttpEntity entity = httpResponse.getEntity();
-
-        // Entity response string
-        String responseString = EntityUtils.toString(entity);
-
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseString);
-
-        // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "New flow storage created";
-
-        // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
-
-        // Assertions
-
-        assertEquals(expected, actual);
-        assertThat(
-                httpResponse.getStatusLine().getStatusCode(),
-                equalTo(HttpStatus.SC_CREATED));
-    }
-
-    @Test
-    @Order(4)
-    public void testFetchFlowStorage() throws Exception {
-        ArrayList<FlowStorage> expected = new ArrayList<>();
-
-        FlowStorage flowStorage = new FlowStorage();
-        flowStorage.setId(1);
-        flowStorage.setFlow("Testflow");
-        flowStorage.setStorage_name("cfe_04");
-        flowStorage.setStorage_type("cfe_04");
-        flowStorage.setStorage_id(1);
-
-        expected.add(flowStorage);
-
-        // Asserting get request
-        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/storage/flow/Testflow");
-
-        requestGet.setHeader("Authorization", "Bearer " + token);
-
-        HttpResponse responseGet = HttpClientBuilder.create().build().execute(requestGet);
-
-        HttpEntity entityGet = responseGet.getEntity();
-
-        String responseStringGet = EntityUtils.toString(entityGet, "UTF-8");
-
-        String expectedJson = new Gson().toJson(expected);
-
-        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertEquals(expectedJson, responseStringGet);
-    }
-
-    @Test
-    @Order(5)
-    public void testFetchFlowStorages() throws Exception {
-
-        ArrayList<FlowStorage> expected = new ArrayList<>();
-
-        FlowStorage flowStorage = new FlowStorage();
-        flowStorage.setId(1);
-        flowStorage.setFlow("Testflow");
-        flowStorage.setStorage_name("cfe_04");
-        flowStorage.setStorage_type("cfe_04");
-        flowStorage.setStorage_id(1);
-
-        expected.add(flowStorage);
-
-        // Asserting get request
-        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/storage/flow");
-
-        requestGet.setHeader("Authorization", "Bearer " + token);
-
-        HttpResponse responseGet = HttpClientBuilder.create().build().execute(requestGet);
-
-        HttpEntity entityGet = responseGet.getEntity();
-
-        String responseStringGet = EntityUtils.toString(entityGet, "UTF-8");
-
-        String expectedJson = new Gson().toJson(expected);
-
-        assertThat(responseGet.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertEquals(expectedJson, responseStringGet);
-    }
-
-    @Test
     @Order(6)
     public void testInsertCaptureStorage() throws Exception {
-        // add sink for capture
-        // insert sink
 
         Sink sink = new Sink();
         sink.setFlowId(1);
@@ -534,59 +528,6 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(11)
-    public void testDeleteNonExistentFlowStorage() throws Exception {
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/" + "Testflow/" + 124);
-
-        // Header
-        delete.setHeader("Authorization", "Bearer " + token);
-
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
-
-        HttpEntity entityDelete = deleteResponse.getEntity();
-
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
-
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
-
-        // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
-
-        // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Record does not exist";
-        assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
-    }
-
-    @Test
-    @Order(12)
-    public void testDeleteFlowStorageInUse() throws Exception {
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/" + "Testflow/" + 1);
-
-
-        // Header
-        delete.setHeader("Authorization", "Bearer " + token);
-
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
-
-        HttpEntity entityDelete = deleteResponse.getEntity();
-
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
-
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
-
-        // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
-        // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Is in use";
-
-        assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
-    }
-
-    @Test
     @Order(13)
     public void testDeleteNonExistentCaptureStorage() throws Exception {
         HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/capture/" + 112 + "/" + 112);
@@ -633,32 +574,6 @@ public class StorageControllerTest extends TestSpringBootInformation {
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Capture = " + 1 + ", with Storage " + 1 + " deleted.";
-
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    @Order(15)
-    public void testDeleteFlowStorage() throws Exception {
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/flow/" + "Testflow/" + 1);
-        // Header
-        delete.setHeader("Authorization", "Bearer " + token);
-
-        HttpResponse deleteResponse = HttpClientBuilder.create().build().execute(delete);
-
-        HttpEntity entityDelete = deleteResponse.getEntity();
-
-        String responseStringGet = EntityUtils.toString(entityDelete, "UTF-8");
-
-        // Parsin respponse as JSONObject
-        JSONObject responseAsJson = new JSONObject(responseStringGet);
-
-        // Creating string from Json that was given as a response
-        String actual = responseAsJson.get("message").toString();
-
-        // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Flow =Testflow, Storage 1 deleted.";
 
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertEquals(expected, actual);

--- a/src/test/java/com/teragrep/cfe18/controllerTests/StorageControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/StorageControllerTest.java
@@ -210,12 +210,12 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(1)
+    @Order(2)
     public void testInsertStorage() {
 
         Storage storage = new Storage();
         storage.setStorageType(Storage.StorageType.cfe_04);
-        storage.setStorageName("cfe_04");
+        storage.setStorageName("cfe_042");
 
         String json = gson.toJson(storage);
 
@@ -258,7 +258,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(2)
+    @Order(3)
     public void testFetchStorages() {
         ArrayList<Storage> expected = new ArrayList<>();
 
@@ -267,7 +267,13 @@ public class StorageControllerTest extends TestSpringBootInformation {
         storage.setStorageType(Storage.StorageType.cfe_04);
         storage.setId(1);
 
+        Storage storage2 = new Storage();
+        storage2.setStorageName("cfe_042");
+        storage2.setStorageType(Storage.StorageType.cfe_04);
+        storage2.setId(2);
+
         expected.add(storage);
+        expected.add(storage2);
 
         String expectedJson = new Gson().toJson(expected);
 
@@ -288,7 +294,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void testFetchStorage() {
         Storage storage = new Storage();
         storage.setStorageName("cfe_04");
@@ -314,7 +320,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(6)
+    @Order(5)
     public void testInsertCaptureStorage() throws Exception {
 
         Sink sink = new Sink();
@@ -369,10 +375,6 @@ public class StorageControllerTest extends TestSpringBootInformation {
         // Get the response from endpoint
         HttpClientBuilder.create().build().execute(request3);
 
-
-        // link the cfe_04 storage to capture
-
-
         CaptureStorage captureStorage = new CaptureStorage();
         captureStorage.setCapture_id(1);
         captureStorage.setStorage_id(1);
@@ -419,7 +421,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(7)
+    @Order(6)
     public void testRetrieveCaptureStorage() throws Exception {
         ArrayList<CaptureStorage> expected = new ArrayList<>();
         CaptureStorage captureStorage = new CaptureStorage();
@@ -446,7 +448,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(8)
+    @Order(7)
     public void testRetrieveCaptureStorages() throws Exception {
         ArrayList<CaptureStorage> expected = new ArrayList<>();
         CaptureStorage captureStorage = new CaptureStorage();
@@ -473,7 +475,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(9)
+    @Order(8)
     public void testDeleteNonExistentStorage() {
         HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/" + 124);
 
@@ -501,7 +503,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(10)
+    @Order(9)
     public void testDeleteStorageInUse() throws Exception {
 
         HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/" + 1);
@@ -528,7 +530,7 @@ public class StorageControllerTest extends TestSpringBootInformation {
     }
 
     @Test
-    @Order(13)
+    @Order(10)
     public void testDeleteNonExistentCaptureStorage() throws Exception {
         HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/capture/" + 112 + "/" + 112);
 
@@ -550,11 +552,11 @@ public class StorageControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
     }
 
     @Test
-    @Order(14)
+    @Order(11)
     public void testDeleteCaptureStorage() throws Exception {
         HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/capture/" + 1 + "/" + 1);
         // Header
@@ -573,16 +575,17 @@ public class StorageControllerTest extends TestSpringBootInformation {
         String actual = responseAsJson.get("message").toString();
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Capture = " + 1 + ", with Storage " + 1 + " deleted.";
+        String expected = "Capture storage deleted";
 
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertEquals(expected, actual);
     }
 
     @Test
-    @Order(16)
+    @Order(12)
     public void testDeleteStorage() {
-        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/" + 1);
+
+        HttpDelete delete = new HttpDelete("http://localhost:" + port + "/storage/" + 2);
         // Header
         delete.setHeader("Authorization", "Bearer " + token);
 
@@ -604,6 +607,5 @@ public class StorageControllerTest extends TestSpringBootInformation {
         assertEquals(expected, actual);
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
     }
-
 
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
@@ -79,8 +79,8 @@ public class ProcedureStorageTest extends DBUnitbase {
     */
     public void testStorageFlowExistence() throws Exception {
         SQLException state = Assertions.assertThrows(SQLException.class, () -> {
-            CallableStatement stmnt = conn.prepareCall("{CALL flow.add_storage(?,?)}");
-            stmnt.setString(1, "FlowThatDontExist");
+            CallableStatement stmnt = conn.prepareCall("{CALL flow.insert_flow_storage(?,?)}");
+            stmnt.setInt(1, 222);
             stmnt.setInt(2, 2);
             stmnt.execute();
 
@@ -100,8 +100,8 @@ public class ProcedureStorageTest extends DBUnitbase {
 
         ITable expectedTable = expectedDataSet.getTable("flow.flow_targets");
 
-        CallableStatement stmnt = conn.prepareCall("CALL flow.add_storage(?,?)");
-        stmnt.setString(1, "flow");
+        CallableStatement stmnt = conn.prepareCall("CALL flow.insert_flow_storage(?,?)");
+        stmnt.setInt(1, 2);
         stmnt.setInt(2, 2);
         stmnt.execute();
 


### PR DESCRIPTION
- Void on delete mapper
- No exceptions signatures in unit tests
- 409 conflict is now returned when in use and 404 when record not found
- Updated apidoc
- Separated FlowController to it's own controller
- TestData is inserted before unit tests

More info on PR #155 