### PR TITLE
Utility endpoints refactored and moved

### DIFF
--- a/src/main/java/com/teragrep/cfe18/ApiUtilityMapper.java
+++ b/src/main/java/com/teragrep/cfe18/ApiUtilityMapper.java
@@ -48,7 +48,7 @@ package com.teragrep.cfe18;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface ApiSessionMapper {
+public interface ApiUtilityMapper {
 
-    int getSession();
+    Integer getSession();
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/ApiUtilityController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/ApiUtilityController.java
@@ -45,10 +45,12 @@
  */
 package com.teragrep.cfe18.handlers;
 
-import com.teragrep.cfe18.ApiSessionMapper;
+import com.teragrep.cfe18.ApiUtilityMapper;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,9 +58,9 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.sql.DataSource;
 
 @RestController
-@RequestMapping(path = "/version")
+@RequestMapping(path = "/v2/meta")
 @SecurityRequirement(name = "api")
-public class ApiSessionController {
+public class ApiUtilityController {
 
     @Autowired
     DataSource dataSource;
@@ -67,14 +69,23 @@ public class ApiSessionController {
     SqlSessionTemplate sqlSessionTemplate;
 
     @Autowired
-    ApiSessionMapper apiSessionMapper;
+    ApiUtilityMapper apiUtilityMapper;
 
     @RequestMapping(
-            path = "",
+            path = "/data-version",
             method = RequestMethod.GET
     )
     public int version() {
-        return apiSessionMapper.getSession();
+        return apiUtilityMapper.getSession();
+    }
+
+    @RequestMapping(
+            path = "/jwt",
+            method = RequestMethod.GET,
+            produces = "application/json"
+    )
+    public String index(@AuthenticationPrincipal Jwt jwt) throws Exception {
+        return String.format("Hello, %s!", jwt.getSubject());
     }
 
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/ApiUtilityController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/ApiUtilityController.java
@@ -75,7 +75,7 @@ public class ApiUtilityController {
             path = "/data-version",
             method = RequestMethod.GET
     )
-    public int version() {
+    public Integer version() {
         return apiUtilityMapper.getSession();
     }
 

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
@@ -62,8 +62,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
@@ -85,15 +83,6 @@ public class CaptureFileController {
 
     @Autowired
     CaptureFileMapper captureFileMapper;
-
-    @RequestMapping(
-            path = "/jwt",
-            method = RequestMethod.GET,
-            produces = "application/json"
-    )
-    public String index(@AuthenticationPrincipal Jwt jwt) throws Exception {
-        return String.format("Hello, %s!", jwt.getSubject());
-    }
 
     @RequestMapping(
             path = "",

--- a/src/main/resources/com/teragrep/cfe18/ApiUtilityMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/ApiUtilityMapper.xml
@@ -2,12 +2,13 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.teragrep.cfe18.ApiSessionMapper">
+<mapper namespace="com.teragrep.cfe18.ApiUtilityMapper">
 
     <!-- GET ALL -->
     <select id="getSession" resultMap="versionNumber" statementType="CALLABLE">
         {CALL cfe_18.current_txn_id()}
     </select>
+
     <resultMap id="versionNumber" type="Integer">
         <result property="version" column="tx_id"/>
     </resultMap>

--- a/src/main/resources/com/teragrep/cfe18/ApiUtilityMapper.xml
+++ b/src/main/resources/com/teragrep/cfe18/ApiUtilityMapper.xml
@@ -9,7 +9,7 @@
         {CALL cfe_18.current_txn_id()}
     </select>
 
-    <resultMap id="versionNumber" type="Integer">
+    <resultMap id="versionNumber" type="java.lang.Integer">
         <result property="version" column="tx_id"/>
     </resultMap>
 

--- a/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
@@ -53,73 +53,78 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-import java.io.IOException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(MigrateDatabaseExtension.class)
-public class TokenTest extends TestSpringBootInformation {
+public class ApiUtilityControllerTest extends TestSpringBootInformation {
 
     @LocalServerPort
     private int port;
 
     // Testing if token works
     @Test
-    public void testToken() throws IOException {
+    @Order(1)
+    public void testToken() {
 
         // Given
-        HttpUriRequest request = new HttpGet("http://localhost:" + port + "/v2/captures/definitions/files/jwt");
+        HttpUriRequest request = new HttpGet("http://localhost:" + port + "/v2/meta/jwt");
         request.setHeader("Authorization", "Bearer " + token);
         // When
 
-        HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+        HttpResponse httpResponse = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
 
         HttpEntity entity = httpResponse.getEntity();
 
-        String responseString = EntityUtils.toString(entity, "UTF-8");
+        String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity, "UTF-8"));
 
         // Then
-        assertThat(httpResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertThat(responseString, equalTo("Hello, subject!"));
+        assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
+        assertEquals("Hello, subject!", responseString);
     }
 
     // Testing that without token there is no access
     @Test
-    public void testInvalidToken() throws IOException {
+    @Order(2)
+    public void testInvalidToken() {
 
         // Given
-        HttpUriRequest request2 = new HttpGet("http://localhost:" + port + "/v2/captures/definitions/files/jwt");
+        HttpUriRequest request2 = new HttpGet("http://localhost:" + port + "/v2/meta/jwt");
         request2.setHeader("Authorization", "Bearer noToken");
 
         // When
 
-        HttpResponse httpResponse2 = HttpClientBuilder.create().build().execute(request2);
+        HttpResponse httpResponse2 = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request2));
 
         // Then
-        assertThat(httpResponse2.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, httpResponse2.getStatusLine().getStatusCode());
     }
 
     // Tests that giving no token returns 500
     @Test
-    public void testNoToken() throws IOException {
+    @Order(3)
+    public void testNoToken() {
 
         // Given
-        HttpUriRequest request2 = new HttpGet("http://localhost:" + port + "/v2/captures/definitions/files/jwt");
+        HttpUriRequest request2 = new HttpGet("http://localhost:" + port + "/v2/meta/jwt");
 
         // When
 
-        HttpResponse httpResponse2 = HttpClientBuilder.create().build().execute(request2);
+        HttpResponse httpResponse2 = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request2));
 
         // Then
-        assertThat(httpResponse2.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, httpResponse2.getStatusLine().getStatusCode());
     }
 
 }

--- a/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
@@ -45,27 +45,37 @@
  */
 package com.teragrep.cfe18.controllerTests;
 
+import com.google.gson.Gson;
+import com.teragrep.cfe18.handlers.entities.Flow;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(MigrateDatabaseExtension.class)
 public class ApiUtilityControllerTest extends TestSpringBootInformation {
+
+    Gson gson = new Gson();
 
     @LocalServerPort
     private int port;
@@ -125,6 +135,109 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
 
         // Then
         assertEquals(HttpStatus.SC_UNAUTHORIZED, httpResponse2.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    @Order(4)
+    public void testVersionIsNumber() {
+
+        Flow flow = new Flow();
+        flow.setName("Testflow");
+
+        String json = gson.toJson(flow);
+
+        // forms the json to requestEntity
+        StringEntity flowEntity = new StringEntity(String.valueOf(json), ContentType.APPLICATION_JSON);
+
+        // Creates the request
+        HttpPut flowRequest = new HttpPut("http://localhost:" + port + "/flow");
+        // set requestEntity to the put request
+        flowRequest.setEntity(flowEntity);
+        // Header
+        flowRequest.setHeader("Authorization", "Bearer " + token);
+
+        // Get the response from endpoint
+        HttpResponse flowResponse = assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(flowRequest));
+
+        // Get the entity from response
+        HttpEntity flowResponseEntity = flowResponse.getEntity();
+
+        // Entity response string
+        String flowAsResponseString = assertDoesNotThrow(() -> EntityUtils.toString(flowResponseEntity));
+
+        // Parsin respponse as JSONObject
+        JSONObject flowAsResponseJson = assertDoesNotThrow(() -> new JSONObject(flowAsResponseString));
+
+        // Creating expected message as JSON Object from the data that was sent towards endpoint
+        String expectedFlow = "New flow created";
+
+        // Creating string from Json that was given as a response
+        String actualFlow = assertDoesNotThrow(() -> flowAsResponseJson.get("message").toString());
+
+        // Given
+        HttpUriRequest request = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
+        request.setHeader("Authorization", "Bearer " + token);
+        // When
+
+        HttpResponse httpResponse = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
+
+        HttpEntity entity = httpResponse.getEntity();
+
+        String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity, "UTF-8"));
+
+        // Validates here that the result is type of Integer
+        Integer result = Integer.valueOf(responseString);
+
+        // Then
+        // Assertions
+        assertEquals(expectedFlow, actualFlow);
+        assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
+        // Asserts that the return is not null.
+        assertNotNull(result);
+    }
+
+    @Test
+    @Order(5)
+    public void testVersionCanBeFetched() {
+
+        // Asserting get request
+        HttpGet requestGet = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
+
+        requestGet.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse responseGet = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestGet));
+
+        HttpEntity entityGet = responseGet.getEntity();
+
+        String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
+
+        Integer version = Integer.valueOf(responseStringGet);
+
+        // Asserting get request
+        HttpGet requestFlow = new HttpGet("http://localhost:" + port + "/flow?version=" + version);
+
+        requestFlow.setHeader("Authorization", "Bearer " + token);
+
+        HttpResponse responseFlow = Assertions
+                .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(requestFlow));
+
+        HttpEntity entityFlow = responseFlow.getEntity();
+
+        String flowAsResponseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityFlow, "UTF-8"));
+
+        ArrayList<Flow> expected = new ArrayList<>();
+        Flow flow = new Flow();
+        flow.setName("Testflow");
+        flow.setId(1);
+        expected.add(flow);
+        String expectedJson = new Gson().toJson(expected);
+
+        // Assertions
+        assertEquals(expectedJson, flowAsResponseString);
+        assertEquals(HttpStatus.SC_OK, responseFlow.getStatusLine().getStatusCode());
+
     }
 
 }

--- a/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
@@ -159,6 +159,10 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
     @Test
     @Order(5)
     public void testVersionCanBeFetched() {
+        TestApiClient testApiClient = new TestApiClient(port, token);
+
+        Integer flowId = testApiClient.insertFlow("Testflow");
+
         HttpGet requestGet = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
 
         requestGet.setHeader("Authorization", "Bearer " + token);
@@ -172,9 +176,7 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
 
         int version = Integer.parseInt(responseStringGet);
 
-        TestApiClient testApiClient = new TestApiClient(port, token);
-
-        HttpResponse response = testApiClient.deleteFlow(1);
+        HttpResponse response = testApiClient.deleteFlow(flowId);
 
         HttpGet requestFlow = new HttpGet("http://localhost:" + port + "/flow?version=" + version);
 

--- a/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
@@ -159,7 +159,6 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
     @Test
     @Order(5)
     public void testVersionCanBeFetched() {
-
         HttpGet requestGet = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
 
         requestGet.setHeader("Authorization", "Bearer " + token);
@@ -172,6 +171,10 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
         String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
 
         int version = Integer.parseInt(responseStringGet);
+
+        TestApiClient testApiClient = new TestApiClient(port, token);
+
+        HttpResponse response = testApiClient.deleteFlow(1);
 
         HttpGet requestFlow = new HttpGet("http://localhost:" + port + "/flow?version=" + version);
 
@@ -192,6 +195,7 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
         String expectedJson = new Gson().toJson(expected);
 
         assertEquals(expectedJson, flowAsResponseString);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
         assertEquals(HttpStatus.SC_OK, responseFlow.getStatusLine().getStatusCode());
 
     }

--- a/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/ApiUtilityControllerTest.java
@@ -51,14 +51,10 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
-import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -141,43 +137,12 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
     @Order(4)
     public void testVersionIsNumber() {
 
-        Flow flow = new Flow();
-        flow.setName("Testflow");
+        TestApiClient testApiClient = new TestApiClient(port, token);
 
-        String json = gson.toJson(flow);
+        Integer flowId = testApiClient.insertFlow("Testflow");
 
-        // forms the json to requestEntity
-        StringEntity flowEntity = new StringEntity(String.valueOf(json), ContentType.APPLICATION_JSON);
-
-        // Creates the request
-        HttpPut flowRequest = new HttpPut("http://localhost:" + port + "/flow");
-        // set requestEntity to the put request
-        flowRequest.setEntity(flowEntity);
-        // Header
-        flowRequest.setHeader("Authorization", "Bearer " + token);
-
-        // Get the response from endpoint
-        HttpResponse flowResponse = assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(flowRequest));
-
-        // Get the entity from response
-        HttpEntity flowResponseEntity = flowResponse.getEntity();
-
-        // Entity response string
-        String flowAsResponseString = assertDoesNotThrow(() -> EntityUtils.toString(flowResponseEntity));
-
-        // Parsin respponse as JSONObject
-        JSONObject flowAsResponseJson = assertDoesNotThrow(() -> new JSONObject(flowAsResponseString));
-
-        // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expectedFlow = "New flow created";
-
-        // Creating string from Json that was given as a response
-        String actualFlow = assertDoesNotThrow(() -> flowAsResponseJson.get("message").toString());
-
-        // Given
         HttpUriRequest request = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
         request.setHeader("Authorization", "Bearer " + token);
-        // When
 
         HttpResponse httpResponse = Assertions
                 .assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(request));
@@ -186,14 +151,8 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
 
         String responseString = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity, "UTF-8"));
 
-        // Validates here that the result is type of Integer
         Integer result = Integer.valueOf(responseString);
 
-        // Then
-        // Assertions
-        assertEquals(expectedFlow, actualFlow);
-        assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
-        // Asserts that the return is not null.
         assertNotNull(result);
     }
 
@@ -201,7 +160,6 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
     @Order(5)
     public void testVersionCanBeFetched() {
 
-        // Asserting get request
         HttpGet requestGet = new HttpGet("http://localhost:" + port + "/v2/meta/data-version");
 
         requestGet.setHeader("Authorization", "Bearer " + token);
@@ -213,9 +171,8 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
 
         String responseStringGet = Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entityGet, "UTF-8"));
 
-        Integer version = Integer.valueOf(responseStringGet);
+        int version = Integer.parseInt(responseStringGet);
 
-        // Asserting get request
         HttpGet requestFlow = new HttpGet("http://localhost:" + port + "/flow?version=" + version);
 
         requestFlow.setHeader("Authorization", "Bearer " + token);
@@ -234,7 +191,6 @@ public class ApiUtilityControllerTest extends TestSpringBootInformation {
         expected.add(flow);
         String expectedJson = new Gson().toJson(expected);
 
-        // Assertions
         assertEquals(expectedJson, flowAsResponseString);
         assertEquals(HttpStatus.SC_OK, responseFlow.getStatusLine().getStatusCode());
 

--- a/src/test/java/com/teragrep/cfe18/controllerTests/TestApiClient.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/TestApiClient.java
@@ -49,6 +49,7 @@ import com.google.gson.Gson;
 import com.teragrep.cfe18.handlers.entities.*;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -89,6 +90,13 @@ public class TestApiClient {
         JSONObject flowAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(flowAsResponse));
 
         return Assertions.assertDoesNotThrow(() -> flowAsJson.getInt("id"));
+    }
+
+    public HttpResponse deleteFlow(final Integer flowId) {
+        HttpDelete flowRequest = new HttpDelete("http://localhost:" + port + "/flow/" + flowId);
+        flowRequest.setHeader("Authorization", "Bearer " + token);
+
+        return Assertions.assertDoesNotThrow(() -> HttpClientBuilder.create().build().execute(flowRequest));
     }
 
     public Integer insertSink(final Integer flowId, final String sinkPort, final String ip, final String protocol) {


### PR DESCRIPTION
Utility endpoints refactored and moved accordingly. Attempted to find a way to test out Api version endpoint but no clear solution was found. Version number changes every time tests were ran. Junit does testing alphabetically but version number changed during every test execution.

Version numbers received during testing: 

25873
54517
83161
111789