### PR TITLE
Initial push for error handler feature

### DIFF
--- a/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
+++ b/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
@@ -55,6 +55,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.sql.SQLException;
+import java.util.UUID;
 
 @RestControllerAdvice
 @Order(1)
@@ -70,10 +71,13 @@ public class DatabaseExceptionHandler {
 
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<String> handleSQLException(SQLException ex) {
-        LOGGER.error(ex.getMessage(), ex);
+        UUID uuid = UUID.randomUUID();
+        LOGGER.error("Error ID {}", uuid, ex);
         JsonObjectBuilder errBuilder = Json.createObjectBuilder();
         MariaDBError mariaDBError = resolver.resolve(ex.getErrorCode());
+        LOGGER.error("MariaDB error message {}", mariaDBError.message());
         errBuilder.add("message", mariaDBError.message());
+        errBuilder.add("UUID", uuid.toString());
         return new ResponseEntity<>(errBuilder.build().toString(), mariaDBError.status());
 
     }

--- a/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
+++ b/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
@@ -74,7 +74,6 @@ public class DatabaseExceptionHandler {
         UUID uuid = UUID.randomUUID();
         JsonObjectBuilder errBuilder = Json.createObjectBuilder();
         MariaDBError mariaDBError = resolver.resolve(ex.getErrorCode());
-        LOGGER.error("MariaDB error message {}", mariaDBError.message());
         LOGGER.error("Error ID and message {} , {}", uuid, mariaDBError.message(), ex);
         errBuilder.add("message", mariaDBError.message());
         errBuilder.add("UUID", uuid.toString());

--- a/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
+++ b/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
@@ -43,37 +43,37 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-USE cfe_18;
-DELIMITER //
-CREATE OR REPLACE PROCEDURE select_capture_definition(id INT, tx_id INT)
-BEGIN
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-        BEGIN
-            ROLLBACK;
-            RESIGNAL;
-        END;
-    IF (tx_id) IS NULL THEN
-        SET @time = (SELECT MAX(transaction_id) FROM mysql.transaction_registry);
-    ELSE
-        SET @time = tx_id;
-    END IF;
+package com.teragrep.cfe18;
 
-    if ((select count(*) from cfe_18.capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time c where c.id = id) = 0) then
-        signal sqlstate '45000' set MYSQL_ERRNO = 8000;
-    end if;
-    SELECT c.id                 AS id,
-           t.tag                AS tag,
-           cs.captureSourceType AS sourcetype,
-           a.app                AS application,
-           ci.captureIndex      AS capture_index
-    FROM cfe_18.capture_definition c
-             INNER JOIN cfe_18.tags FOR SYSTEM_TIME AS OF TRANSACTION @time t ON t.id = c.tag_id
-             INNER JOIN cfe_18.captureSourcetype FOR SYSTEM_TIME AS OF TRANSACTION @time cs
-                        ON c.captureSourcetype_id = cs.id
-             INNER JOIN cfe_18.application FOR SYSTEM_TIME AS OF TRANSACTION @time a ON c.application_id = a.id
-             INNER JOIN cfe_18.captureIndex FOR SYSTEM_TIME AS OF TRANSACTION @time ci ON c.captureIndex_id = ci.id
-    where c.id = id;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-END;
-//
-DELIMITER ;
+import java.sql.SQLException;
+
+@RestControllerAdvice
+public class DatabaseExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseExceptionHandler.class);
+
+    MariaDBErrorResolver resolver;
+
+    public DatabaseExceptionHandler(MariaDBErrorResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @ExceptionHandler(SQLException.class)
+    public ResponseEntity<String> handleSQLException(SQLException ex) {
+        LOGGER.error(ex.getMessage(), ex);
+        JsonObjectBuilder errBuilder = Json.createObjectBuilder();
+        MariaDBError mariaDBError = resolver.resolve(ex.getErrorCode());
+        errBuilder.add("message", mariaDBError.message());
+        return new ResponseEntity<>(errBuilder.build().toString(), mariaDBError.status());
+
+    }
+
+}

--- a/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
+++ b/src/main/java/com/teragrep/cfe18/DatabaseExceptionHandler.java
@@ -72,10 +72,10 @@ public class DatabaseExceptionHandler {
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<String> handleSQLException(SQLException ex) {
         UUID uuid = UUID.randomUUID();
-        LOGGER.error("Error ID {}", uuid, ex);
         JsonObjectBuilder errBuilder = Json.createObjectBuilder();
         MariaDBError mariaDBError = resolver.resolve(ex.getErrorCode());
         LOGGER.error("MariaDB error message {}", mariaDBError.message());
+        LOGGER.error("Error ID and message {} , {}", uuid, mariaDBError.message(), ex);
         errBuilder.add("message", mariaDBError.message());
         errBuilder.add("UUID", uuid.toString());
         return new ResponseEntity<>(errBuilder.build().toString(), mariaDBError.status());

--- a/src/main/java/com/teragrep/cfe18/GenericExceptionHandler.java
+++ b/src/main/java/com/teragrep/cfe18/GenericExceptionHandler.java
@@ -50,32 +50,25 @@ import jakarta.json.JsonObjectBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.sql.SQLException;
+import java.util.UUID;
 
 @RestControllerAdvice
-@Order(1)
-public class DatabaseExceptionHandler {
+@Order(2)
+public class GenericExceptionHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseExceptionHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenericExceptionHandler.class);
 
-    MariaDBErrorResolver resolver;
-
-    public DatabaseExceptionHandler(MariaDBErrorResolver resolver) {
-        this.resolver = resolver;
-    }
-
-    @ExceptionHandler(SQLException.class)
-    public ResponseEntity<String> handleSQLException(SQLException ex) {
-        LOGGER.error(ex.getMessage(), ex);
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) {
+        UUID s = UUID.randomUUID();
+        LOGGER.error("Error ID {}", s, ex);
         JsonObjectBuilder errBuilder = Json.createObjectBuilder();
-        MariaDBError mariaDBError = resolver.resolve(ex.getErrorCode());
-        errBuilder.add("message", mariaDBError.message());
-        return new ResponseEntity<>(errBuilder.build().toString(), mariaDBError.status());
-
+        errBuilder.add("message", "an error occured, use errorId {" + s + "} for correlation with administrator");
+        return new ResponseEntity<>(errBuilder.build().toString(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
-
 }

--- a/src/main/java/com/teragrep/cfe18/MariaDBError.java
+++ b/src/main/java/com/teragrep/cfe18/MariaDBError.java
@@ -43,37 +43,35 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-USE cfe_18;
-DELIMITER //
-CREATE OR REPLACE PROCEDURE select_capture_definition(id INT, tx_id INT)
-BEGIN
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-        BEGIN
-            ROLLBACK;
-            RESIGNAL;
-        END;
-    IF (tx_id) IS NULL THEN
-        SET @time = (SELECT MAX(transaction_id) FROM mysql.transaction_registry);
-    ELSE
-        SET @time = tx_id;
-    END IF;
+package com.teragrep.cfe18;
 
-    if ((select count(*) from cfe_18.capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time c where c.id = id) = 0) then
-        signal sqlstate '45000' set MYSQL_ERRNO = 8000;
-    end if;
-    SELECT c.id                 AS id,
-           t.tag                AS tag,
-           cs.captureSourceType AS sourcetype,
-           a.app                AS application,
-           ci.captureIndex      AS capture_index
-    FROM cfe_18.capture_definition c
-             INNER JOIN cfe_18.tags FOR SYSTEM_TIME AS OF TRANSACTION @time t ON t.id = c.tag_id
-             INNER JOIN cfe_18.captureSourcetype FOR SYSTEM_TIME AS OF TRANSACTION @time cs
-                        ON c.captureSourcetype_id = cs.id
-             INNER JOIN cfe_18.application FOR SYSTEM_TIME AS OF TRANSACTION @time a ON c.application_id = a.id
-             INNER JOIN cfe_18.captureIndex FOR SYSTEM_TIME AS OF TRANSACTION @time ci ON c.captureIndex_id = ci.id
-    where c.id = id;
+import org.springframework.http.HttpStatus;
 
-END;
-//
-DELIMITER ;
+public enum MariaDBError {
+
+    MISSING(8000, HttpStatus.NOT_FOUND, "Record does not exist"),
+    INUSE(1451, HttpStatus.BAD_REQUEST, "Is in use"),
+    UNKNOWN(0, HttpStatus.INTERNAL_SERVER_ERROR, "Something went wrong"),;
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    private MariaDBError(int errorCode, HttpStatus httpStatus, String message) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public int errorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus status() {
+        return httpStatus;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/teragrep/cfe18/MariaDBError.java
+++ b/src/main/java/com/teragrep/cfe18/MariaDBError.java
@@ -49,8 +49,16 @@ import org.springframework.http.HttpStatus;
 
 public enum MariaDBError {
 
-    MISSING(8000, HttpStatus.NOT_FOUND, "Record does not exist"),
-    INUSE(1451, HttpStatus.BAD_REQUEST, "Is in use"),
+    MISSING(-15536, HttpStatus.NOT_FOUND, "Record does not exist"),
+    INTEGRATIONTYPECONFLICT(-15526, HttpStatus.CONFLICT, "Integration type mismatch"),
+    HOSTSUSEHUB(-15516, HttpStatus.BAD_REQUEST, "Hosts use the hub"),
+    TAGMD5SUMERROR(-15506, HttpStatus.INTERNAL_SERVER_ERROR, "Tag mismatches with the given tag_path"),
+    DUPLICATEHOST(-15496, HttpStatus.CONFLICT, "Tag already exists on the same host through different channels"),
+    HOSTISAHUB(-15476, HttpStatus.CONFLICT, "Host is a hub"),
+    MISSINGCONSTRAINT(1452, HttpStatus.NOT_FOUND, "Record does not exist"),
+    INUSE(1451, HttpStatus.CONFLICT, "Is in use"),
+    DUPLICATEENTRY(1062, HttpStatus.CONFLICT, "Duplicate entry"),
+    GENERICERR(1644, HttpStatus.CONFLICT, "Generic user error"),
     UNKNOWN(0, HttpStatus.INTERNAL_SERVER_ERROR, "Something went wrong"),;
 
     private final int errorCode;

--- a/src/main/java/com/teragrep/cfe18/MariaDBErrorResolver.java
+++ b/src/main/java/com/teragrep/cfe18/MariaDBErrorResolver.java
@@ -43,37 +43,32 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-USE cfe_18;
-DELIMITER //
-CREATE OR REPLACE PROCEDURE select_capture_definition(id INT, tx_id INT)
-BEGIN
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-        BEGIN
-            ROLLBACK;
-            RESIGNAL;
-        END;
-    IF (tx_id) IS NULL THEN
-        SET @time = (SELECT MAX(transaction_id) FROM mysql.transaction_registry);
-    ELSE
-        SET @time = tx_id;
-    END IF;
+package com.teragrep.cfe18;
 
-    if ((select count(*) from cfe_18.capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time c where c.id = id) = 0) then
-        signal sqlstate '45000' set MYSQL_ERRNO = 8000;
-    end if;
-    SELECT c.id                 AS id,
-           t.tag                AS tag,
-           cs.captureSourceType AS sourcetype,
-           a.app                AS application,
-           ci.captureIndex      AS capture_index
-    FROM cfe_18.capture_definition c
-             INNER JOIN cfe_18.tags FOR SYSTEM_TIME AS OF TRANSACTION @time t ON t.id = c.tag_id
-             INNER JOIN cfe_18.captureSourcetype FOR SYSTEM_TIME AS OF TRANSACTION @time cs
-                        ON c.captureSourcetype_id = cs.id
-             INNER JOIN cfe_18.application FOR SYSTEM_TIME AS OF TRANSACTION @time a ON c.application_id = a.id
-             INNER JOIN cfe_18.captureIndex FOR SYSTEM_TIME AS OF TRANSACTION @time ci ON c.captureIndex_id = ci.id
-    where c.id = id;
+import org.springframework.stereotype.Component;
 
-END;
-//
-DELIMITER ;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class MariaDBErrorResolver {
+
+    private final Map<Integer, MariaDBError> registry;
+
+    // populate resolver on initialization
+    public MariaDBErrorResolver() {
+        this.registry = new HashMap<>();
+        for (MariaDBError error : MariaDBError.values()) {
+            this.registry.put(error.errorCode(), error);
+        }
+    }
+
+    public MariaDBErrorResolver(Map<Integer, MariaDBError> registry) {
+        this.registry = registry;
+    }
+
+    public MariaDBError resolve(int errorCode) {
+        return registry.get(errorCode);
+    }
+
+}

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureDefinitionController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureDefinitionController.java
@@ -53,7 +53,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import org.json.JSONObject;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +62,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -110,26 +108,8 @@ public class CaptureDefinitionController {
             )
     })
     public ResponseEntity<String> get(@PathVariable("id") Integer id, @RequestParam(required = false) Integer version) {
-        try {
-            CaptureDefinition captureDefinition = captureDefinitionMapper.get(id, version);
-            return new ResponseEntity<>(captureDefinition.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().toString());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureDefinition captureDefinition = captureDefinitionMapper.get(id, version);
+        return new ResponseEntity<>(captureDefinition.toString(), HttpStatus.OK);
     }
 
     @RequestMapping(

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
@@ -65,7 +65,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -109,27 +108,19 @@ public class CaptureFileController {
     })
     public ResponseEntity<String> create(@RequestBody CaptureFile newCapture) {
         LOGGER.info("About to insert <[{}]>", newCapture);
-        try {
-            CaptureFile c = captureFileMapper
-                    .create(
-                            newCapture.getTag(), newCapture.getRetentionTime(), newCapture.getCategory(),
-                            newCapture.getApplication(), newCapture.getIndex(), newCapture.getSourceType(),
-                            newCapture.getProtocol(), newCapture.getFlow(), newCapture.getTagPath(),
-                            newCapture.getCapturePath(), newCapture.getFileProcessingTypeId()
-                    );
-            LOGGER.debug("Values returned <[{}]>", c);
-            JSONObject jsonObjectFile = new JSONObject();
-            jsonObjectFile.put("id", c.getId());
-            jsonObjectFile.put("message", "New capture created");
-            return new ResponseEntity<>(jsonObjectFile.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newCapture.getId());
-            jsonErr.put("message", ex.getCause().toString());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+
+        CaptureFile c = captureFileMapper
+                .create(
+                        newCapture.getTag(), newCapture.getRetentionTime(), newCapture.getCategory(),
+                        newCapture.getApplication(), newCapture.getIndex(), newCapture.getSourceType(),
+                        newCapture.getProtocol(), newCapture.getFlow(), newCapture.getTagPath(),
+                        newCapture.getCapturePath(), newCapture.getFileProcessingTypeId()
+                );
+        LOGGER.debug("Values returned <[{}]>", c);
+        JSONObject jsonObjectFile = new JSONObject();
+        jsonObjectFile.put("id", c.getId());
+        jsonObjectFile.put("message", "New capture created");
+        return new ResponseEntity<>(jsonObjectFile.toString(), HttpStatus.CREATED);
 
     }
 
@@ -162,26 +153,9 @@ public class CaptureFileController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            CaptureFile c = captureFileMapper.get(id, version);
-            return new ResponseEntity<>(c, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().toString());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureFile c = captureFileMapper.get(id, version);
+        return new ResponseEntity<>(c, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -239,32 +213,10 @@ public class CaptureFileController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting capture with id <[{}]>", id);
-        try {
-            captureFileMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Capture deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        captureFileMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Capture deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureFileController.java
@@ -108,7 +108,6 @@ public class CaptureFileController {
     })
     public ResponseEntity<String> create(@RequestBody CaptureFile newCapture) {
         LOGGER.info("About to insert <[{}]>", newCapture);
-
         CaptureFile c = captureFileMapper
                 .create(
                         newCapture.getTag(), newCapture.getRetentionTime(), newCapture.getCategory(),

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureGroupMembersController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureGroupMembersController.java
@@ -62,7 +62,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -120,48 +119,13 @@ public class CaptureGroupMembersController {
     })
     public ResponseEntity<String> create(@PathVariable("groupId") int groupId, @RequestBody int captureId) {
         LOGGER.info("About to insert <[{}]>", captureId);
-        try {
-            Integer returnedCaptureId = captureGroupMapper.create(groupId, captureId);
-            LOGGER.info("Values returned what happened with linking <[{}]>", returnedCaptureId);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", returnedCaptureId);
-            jsonObject.put("message", "Capture linked with group");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", groupId);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                int error = ((SQLException) cause).getErrorCode();
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                LOGGER.info(state);
-                switch (state) {
-                    case "1644-45000":
-                        jsonErr.put("message", "Type mismatch between capture group and capture");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                    case "1644-45001":
-                        jsonErr.put("message", "Capture does not exist");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                    case "1644-45002":
-                        jsonErr.put("message", "Group does not exist");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                    case "1062-23000":
-                        jsonErr.put("message", "Tag already exists within given group");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                    case "1644-17001":
-                        jsonErr.put("message", "Tag already exists on the same host through different channels");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                    default:
-                        jsonErr.put("message", "Error unrecognized, contact admin");
-                        return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        Integer returnedCaptureId = captureGroupMapper.create(groupId, captureId);
+        LOGGER.info("Values returned what happened with linking <[{}]>", returnedCaptureId);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", returnedCaptureId);
+        jsonObject.put("message", "Capture linked with group");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -185,26 +149,8 @@ public class CaptureGroupMembersController {
             @PathVariable("groupId") int groupId,
             @RequestParam(required = false) Integer version
     ) {
-        try {
-            List<Integer> cg = captureGroupMapper.get(groupId, version);
-            return new ResponseEntity<>(cg.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("message", ex.getCause().getMessage());
-            jsonErr.put("id", groupId);
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        List<Integer> cg = captureGroupMapper.get(groupId, version);
+        return new ResponseEntity<>(cg.toString(), HttpStatus.OK);
     }
 
     @RequestMapping(
@@ -234,28 +180,11 @@ public class CaptureGroupMembersController {
             @PathVariable("captureId") int captureId
     ) {
         LOGGER.info("Deleting Capture from group <[{}]>", groupId);
-        try {
-            captureGroupMapper.delete(groupId, captureId);
-            JSONObject j = new JSONObject();
-            j.put("id", groupId);
-            j.put("message", "Capture deleted from group");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", groupId);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        captureGroupMapper.delete(groupId, captureId);
+        JSONObject j = new JSONObject();
+        j.put("id", groupId);
+        j.put("message", "Capture deleted from group");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureGroupsController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureGroupsController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -113,34 +112,17 @@ public class CaptureGroupsController {
     })
     public ResponseEntity<String> create(@RequestBody CaptureGroups newCaptureGroups) {
         LOGGER.info("About to insert <[{}]>", newCaptureGroups);
-        try {
-            CaptureGroups c = captureGroupsMapper
-                    .create(
-                            newCaptureGroups.getCaptureGroupName(), newCaptureGroups.getCaptureGroupType(),
-                            newCaptureGroups.getFlowId()
-                    );
-            LOGGER.debug("Values returned <[{}]>", c);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", c.getId());
-            jsonObject.put("message", "New capture group created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newCaptureGroups.getId());
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureGroups c = captureGroupsMapper
+                .create(
+                        newCaptureGroups.getCaptureGroupName(), newCaptureGroups.getCaptureGroupType(),
+                        newCaptureGroups.getFlowId()
+                );
+        LOGGER.debug("Values returned <[{}]>", c);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", c.getId());
+        jsonObject.put("message", "New capture group created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -175,26 +157,9 @@ public class CaptureGroupsController {
             @PathVariable("groupId") int groupId,
             @RequestParam(required = false) Integer version
     ) {
-        try {
-            CaptureGroups cg = captureGroupsMapper.get(groupId, version);
-            return new ResponseEntity<>(cg, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", groupId);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureGroups cg = captureGroupsMapper.get(groupId, version);
+        return new ResponseEntity<>(cg, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -257,32 +222,11 @@ public class CaptureGroupsController {
     })
     public ResponseEntity<String> delete(@PathVariable("groupId") int groupId) {
         LOGGER.info("Deleting Capture group <[{}]>", groupId);
-        try {
-            captureGroupsMapper.delete(groupId);
-            JSONObject j = new JSONObject();
-            j.put("id", groupId);
-            j.put("message", "Capture group deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", groupId);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        captureGroupsMapper.delete(groupId);
+        JSONObject j = new JSONObject();
+        j.put("id", groupId);
+        j.put("message", "Capture group deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureMetaController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureMetaController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -117,32 +116,17 @@ public class CaptureMetaController {
     ) {
         newCaptureMeta.setCaptureId(captureId);
         LOGGER.info("About to insert <[{}]>", newCaptureMeta);
-        try {
-            CaptureMeta cm = captureMetaMapper
-                    .create(
-                            newCaptureMeta.getCaptureId(), newCaptureMeta.getCaptureMetaKey(),
-                            newCaptureMeta.getCaptureMetaValue()
-                    );
-            LOGGER.debug("Values returned <[{}]>", cm);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", captureId);
-            jsonObject.put("message", "New capture meta created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", captureId);
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.BAD_REQUEST);
-        }
+        CaptureMeta cm = captureMetaMapper
+                .create(
+                        newCaptureMeta.getCaptureId(), newCaptureMeta.getCaptureMetaKey(),
+                        newCaptureMeta.getCaptureMetaValue()
+                );
+        LOGGER.debug("Values returned <[{}]>", cm);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", captureId);
+        jsonObject.put("message", "New capture meta created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -172,25 +156,8 @@ public class CaptureMetaController {
             @RequestParam(required = false) Integer version
     ) {
         LOGGER.info("About to fetch <[{},{}]>", captureId, key);
-        try {
-            List<CaptureMeta> cm = captureMetaMapper.get(captureId, key, version);
-            return new ResponseEntity<>(cm.toString(), HttpStatus.OK);
-
-        }
-        catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", captureId);
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.BAD_REQUEST);
-        }
+        List<CaptureMeta> cm = captureMetaMapper.get(captureId, key, version);
+        return new ResponseEntity<>(cm.toString(), HttpStatus.OK);
     }
 
     // Delete
@@ -222,19 +189,11 @@ public class CaptureMetaController {
             @RequestParam(required = false) String key
     ) {
         LOGGER.info("Deleting Capture meta <[{}]>", captureId);
-        try {
-            captureMetaMapper.delete(captureId, key);
-            JSONObject j = new JSONObject();
-            j.put("id", captureId);
-            j.put("message", "Capture meta deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", captureId);
-            jsonErr.put("message", ex.getCause());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        captureMetaMapper.delete(captureId, key);
+        JSONObject j = new JSONObject();
+        j.put("id", captureId);
+        j.put("message", "Capture meta deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/CaptureRelpController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/CaptureRelpController.java
@@ -66,7 +66,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -110,26 +109,18 @@ public class CaptureRelpController {
     })
     public ResponseEntity<String> create(@RequestBody CaptureRelp newCapture) {
         LOGGER.info("About to insert <[{}]>", newCapture);
-        try {
-            CaptureRelp c = captureRelpMapper
-                    .create(
-                            newCapture.getTag(), newCapture.getRetentionTime(), newCapture.getCategory(),
-                            newCapture.getApplication(), newCapture.getIndex(), newCapture.getSourceType(),
-                            newCapture.getProtocol(), newCapture.getFlow()
-                    );
-            LOGGER.debug("Values returned <[{}]>", c);
-            JSONObject jsonObjectRelp = new JSONObject();
-            jsonObjectRelp.put("id", c.getId());
-            jsonObjectRelp.put("message", "New capture created");
-            return new ResponseEntity<>(jsonObjectRelp.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newCapture.getId());
-            jsonErr.put("message", ex.getCause().toString());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureRelp c = captureRelpMapper
+                .create(
+                        newCapture.getTag(), newCapture.getRetentionTime(), newCapture.getCategory(),
+                        newCapture.getApplication(), newCapture.getIndex(), newCapture.getSourceType(),
+                        newCapture.getProtocol(), newCapture.getFlow()
+                );
+        LOGGER.debug("Values returned <[{}]>", c);
+        JSONObject jsonObjectRelp = new JSONObject();
+        jsonObjectRelp.put("id", c.getId());
+        jsonObjectRelp.put("message", "New capture created");
+        return new ResponseEntity<>(jsonObjectRelp.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -161,26 +152,9 @@ public class CaptureRelpController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            CaptureRelp c = captureRelpMapper.get(id, version);
-            return new ResponseEntity<>(c, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().toString());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        CaptureRelp c = captureRelpMapper.get(id, version);
+        return new ResponseEntity<>(c, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -238,32 +212,11 @@ public class CaptureRelpController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting capture with id <[{}]>", id);
-        try {
-            captureRelpMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Capture deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        captureRelpMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Capture deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/Cfe04TransformController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/Cfe04TransformController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -136,25 +135,9 @@ public class Cfe04TransformController {
             @PathVariable Integer id,
             @RequestParam(required = false) Integer version
     ) {
-        try {
-            List<Cfe04Transform> cfe04Transforms = cfe04TransformMapper.getAllTransformsForCfe04Id(id, version);
-            return new ResponseEntity<>(cfe04Transforms, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            final Throwable cause = ex.getCause();
-            LOGGER.error(cause.getMessage(), cause);
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given id");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        List<Cfe04Transform> cfe04Transforms = cfe04TransformMapper.getAllTransformsForCfe04Id(id, version);
+        return new ResponseEntity<>(cfe04Transforms, HttpStatus.OK);
+
     }
 
     // New transforms for cfe_04
@@ -187,39 +170,19 @@ public class Cfe04TransformController {
     })
     public ResponseEntity<String> addNewCfe04Transform(@RequestBody Cfe04Transform newCfe04Transform) {
         LOGGER.info("About to insert <[{}]>", newCfe04Transform);
-        try {
-            Cfe04Transform cfe04Transform = cfe04TransformMapper
-                    .addNewCfe04Transform(
-                            newCfe04Transform.getCfe04Id(), newCfe04Transform.getName(),
-                            newCfe04Transform.isWriteMeta(), newCfe04Transform.isWriteDefault(),
-                            newCfe04Transform.getDefaultValue(), newCfe04Transform.getDestinationKey(),
-                            newCfe04Transform.getRegex(), newCfe04Transform.getFormat()
-                    );
-            LOGGER.debug("Values returned <[{}]>", cfe04Transform);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", cfe04Transform.getId());
-            jsonObject.put("message", "New cfe_04 transforms created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            final Throwable cause = ex.getCause();
-            // 1452-23000
-            if (cause instanceof SQLException) {
-                int error = ((SQLException) cause).getErrorCode();
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                JSONObject jsonErr = new JSONObject();
-                jsonErr.put("id", newCfe04Transform.getId());
-                if (state.equals("1452-23000")) {
-                    jsonErr.put("message", "No such cfe_04 id");
-                }
-                else {
-                    jsonErr.put("message", "Error unrecognized, contact admin");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
+        Cfe04Transform cfe04Transform = cfe04TransformMapper
+                .addNewCfe04Transform(
+                        newCfe04Transform.getCfe04Id(), newCfe04Transform.getName(), newCfe04Transform.isWriteMeta(),
+                        newCfe04Transform.isWriteDefault(), newCfe04Transform.getDefaultValue(),
+                        newCfe04Transform.getDestinationKey(), newCfe04Transform.getRegex(),
+                        newCfe04Transform.getFormat()
+                );
+        LOGGER.debug("Values returned <[{}]>", cfe04Transform);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", cfe04Transform.getId());
+        jsonObject.put("message", "New cfe_04 transforms created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
 
-        }
     }
 
     // Delete cfe_04 transforms
@@ -255,28 +218,11 @@ public class Cfe04TransformController {
         LOGGER.info("Deleting cfe_04 transforms with id <[{}]>", id);
         JSONObject jsonErr = new JSONObject();
         jsonErr.put("id", id);
-        try {
-            cfe04TransformMapper.deleteCfe04TransformById(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "cfe_04 transforms with id of " + id + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        cfe04TransformMapper.deleteCfe04TransformById(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "cfe_04 transforms with id of " + id + " deleted.");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FileProcessingTypeController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -113,26 +112,16 @@ public class FileProcessingTypeController {
     })
     public ResponseEntity<String> create(@RequestBody FileProcessing newFileProcessing) {
         LOGGER.info("About to insert <[{}]>", newFileProcessing);
-        try {
-            FileProcessing n = fileProcessingTypeMapper
-                    .create(
-                            newFileProcessing.getTemplate(), newFileProcessing.getRuleset(),
-                            newFileProcessing.getName(), newFileProcessing.getInputtype().toString(),
-                            newFileProcessing.getInputvalue()
-                    );
-            LOGGER.debug("Values returned <[{}]>", n);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", n.getId());
-            jsonObject.put("message", "New file processing type created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newFileProcessing.getId());
-            jsonErr.put("message", ex.getCause().getMessage());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        FileProcessing n = fileProcessingTypeMapper
+                .create(
+                        newFileProcessing.getTemplate(), newFileProcessing.getRuleset(), newFileProcessing.getName(),
+                        newFileProcessing.getInputtype().toString(), newFileProcessing.getInputvalue()
+                );
+        LOGGER.debug("Values returned <[{}]>", n);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", n.getId());
+        jsonObject.put("message", "New file processing type created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
     }
 
     @RequestMapping(
@@ -164,26 +153,9 @@ public class FileProcessingTypeController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            FileProcessing fc = fileProcessingTypeMapper.get(id, version);
-            return new ResponseEntity<>(fc, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        FileProcessing fc = fileProcessingTypeMapper.get(id, version);
+        return new ResponseEntity<>(fc, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -246,32 +218,10 @@ public class FileProcessingTypeController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") Integer id) {
         LOGGER.info("Deleting file processing type  <[{}]>", id);
-        try {
-            fileProcessingTypeMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "File processing type deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        fileProcessingTypeMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "File processing type deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/FlowController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FlowController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -190,31 +189,10 @@ public class FlowController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting flow  <[{}]>", id);
-        try {
-            flowMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Flow deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        flowMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Flow deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/FlowController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/FlowController.java
@@ -112,21 +112,13 @@ public class FlowController {
     })
     public ResponseEntity<String> create(@RequestBody Flow newFlow) {
         LOGGER.info("About to insert <[{}]>", newFlow);
-        try {
-            Flow f = flowMapper.create(newFlow.getName());
-            LOGGER.debug("Values returned <[{}]>", f);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", f.getId());
-            jsonObject.put("message", "New flow created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newFlow.getId());
-            jsonErr.put("message", ex.getCause().toString());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        Flow f = flowMapper.create(newFlow.getName());
+        LOGGER.debug("Values returned <[{}]>", f);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", f.getId());
+        jsonObject.put("message", "New flow created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(

--- a/src/main/java/com/teragrep/cfe18/handlers/HostFileController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/HostFileController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -118,32 +117,13 @@ public class HostFileController {
     })
     public ResponseEntity<String> create(@RequestBody HostFile newHostfile) {
         LOGGER.info("About to insert <[{}]>", newHostfile);
-        try {
-            HostFile hf = hostFileMapper.create(newHostfile.getMd5(), newHostfile.getFqHost(), newHostfile.getHubFq());
-            LOGGER.debug("Values returned <[{}]>", hf);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", hf.getId());
-            jsonObject.put("message", "New host created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newHostfile.getId());
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "ID,MD5 or fqhost already exists");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Host exists for a different type or hub does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        HostFile hf = hostFileMapper.create(newHostfile.getMd5(), newHostfile.getFqHost(), newHostfile.getHubFq());
+        LOGGER.debug("Values returned <[{}]>", hf);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", hf.getId());
+        jsonObject.put("message", "New host created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -175,26 +155,9 @@ public class HostFileController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            HostFile hf = hostFileMapper.get(id, version);
-            return new ResponseEntity<>(hf, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist OR host retrieved is a hub");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        HostFile hf = hostFileMapper.get(id, version);
+        return new ResponseEntity<>(hf, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -252,33 +215,12 @@ public class HostFileController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting Host  <[{}]>", id);
-        try {
-            hostFileMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Host deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("messgae", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
+        hostFileMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Host deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
 
-        }
     }
 
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/HostGroupController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/HostGroupController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -116,23 +115,9 @@ public class HostGroupController {
             @PathVariable("name") String name,
             @RequestParam(required = false) Integer version
     ) {
-        JSONObject jsonErr = new JSONObject();
-        try {
-            List<HostGroup> hg = hostGroupMapper.getHostGroupByName(name, version);
-            return new ResponseEntity<>(hg, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given host group name");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        List<HostGroup> hg = hostGroupMapper.getHostGroupByName(name, version);
+        return new ResponseEntity<>(hg, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -191,35 +176,13 @@ public class HostGroupController {
     })
     public ResponseEntity<String> newHostGroup(@RequestBody HostGroup newHostGroup) {
         LOGGER.info("About to insert <[{}]>", newHostGroup);
-        try {
-            HostGroup hg = hostGroupMapper
-                    .addNewHostGroup(newHostGroup.getHost_id(), newHostGroup.getHost_group_name());
-            LOGGER.debug("Values returned <[{}]>", hg);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("host_group_id", hg.getId());
-            jsonObject.put("message", "New host group created with name = " + hg.getHost_group_name());
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newHostGroup.getId());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                // Get specific error type
-                int error = ((SQLException) cause).getErrorCode();
-                // Link error with state to get accurate error status
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                if (state.equals("1452-23000")) {
-                    jsonErr.put("message", "Type mismatch between host group and host");
-                }
-                else if (state.equals("1644-45000")) {
-                    jsonErr.put("message", "Host does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        HostGroup hg = hostGroupMapper.addNewHostGroup(newHostGroup.getHost_id(), newHostGroup.getHost_group_name());
+        LOGGER.debug("Values returned <[{}]>", hg);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("host_group_id", hg.getId());
+        jsonObject.put("message", "New host group created with name = " + hg.getHost_group_name());
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     // Delete
@@ -253,27 +216,10 @@ public class HostGroupController {
     })
     public ResponseEntity<String> removeHost(@PathVariable("name") String name) {
         LOGGER.info("Deleting Host Group <[{}]>", name);
-        JSONObject jsonErr = new JSONObject();
-        try {
-            hostGroupMapper.deleteHostGroup(name);
-            JSONObject j = new JSONObject();
-            j.put("message", "Host Group " + name + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        hostGroupMapper.deleteHostGroup(name);
+        JSONObject j = new JSONObject();
+        j.put("message", "Host Group " + name + " deleted.");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/HostMetaController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/HostMetaController.java
@@ -114,27 +114,9 @@ public class HostMetaController {
             )
     })
     public ResponseEntity<?> getHostMeta(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            List<HostMeta> hm = hostMetaMapper.getHostMetaById(id, version);
-            return new ResponseEntity<>(hm, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given host_meta_id");
-                }
-                else if (state.equals("45100")) {
-                    jsonErr.put("message", "IP and/or Interface is missing");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        List<HostMeta> hm = hostMetaMapper.getHostMetaById(id, version);
+        return new ResponseEntity<>(hm, HttpStatus.OK);
+
     }
 
     // GET ALL Hostmeta. IP and Interface excluded.
@@ -509,30 +491,10 @@ public class HostMetaController {
     })
     public ResponseEntity<String> removeHostMeta(@PathVariable("id") int id) {
         LOGGER.info("Deleting Hostmeta <[{}]>", id);
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", id);
-        jsonErr.put("message", "Unexpected error occurred");
-        try {
-            hostMetaMapper.deleteHostmeta(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Hostmeta with id =  " + id + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        hostMetaMapper.deleteHostmeta(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Hostmeta with id =  " + id + " deleted.");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/HostRelpController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/HostRelpController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -118,36 +117,13 @@ public class HostRelpController {
     })
     public ResponseEntity<String> create(@RequestBody HostRelp newHostRelp) {
         LOGGER.info("About to insert <[{}]>", newHostRelp);
-        try {
-            HostRelp hr = hostRelpMapper.create(newHostRelp.getMd5(), newHostRelp.getFqHost());
-            LOGGER.debug("Values returned <[{}]>", hr);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", hr.getId());
-            jsonObject.put("message", "New host created with relp type");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newHostRelp.getId());
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                // Get specific error type
-                int error = ((SQLException) cause).getErrorCode();
-                // Link error with state to get accurate error status
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                if (state.equals("1062-23000")) {
-                    jsonErr.put("message", "ID,MD5 or fqhost already exists");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Host exists with different type");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        HostRelp hr = hostRelpMapper.create(newHostRelp.getMd5(), newHostRelp.getFqHost());
+        LOGGER.debug("Values returned <[{}]>", hr);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", hr.getId());
+        jsonObject.put("message", "New host created with relp type");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -179,25 +155,9 @@ public class HostRelpController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            HostRelp hr = hostRelpMapper.get(id, version);
-            return new ResponseEntity<>(hr, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        HostRelp hr = hostRelpMapper.get(id, version);
+        return new ResponseEntity<>(hr, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -255,31 +215,10 @@ public class HostRelpController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting Host  <[{}]>", id);
-        try {
-            hostRelpMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Host deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        hostRelpMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Host deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/HubController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/HubController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -116,24 +115,9 @@ public class HubController {
             @PathVariable("hub_id") int hub_id,
             @RequestParam(required = false) Integer version
     ) {
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", hub_id);
-        try {
-            Hub h = hubMapper.getHubById(hub_id, version);
-            return new ResponseEntity<>(h, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given hub_id");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        Hub h = hubMapper.getHubById(hub_id, version);
+        return new ResponseEntity<>(h, HttpStatus.OK);
+
     }
 
     // Get ALL Hubs
@@ -193,31 +177,13 @@ public class HubController {
     })
     public ResponseEntity<String> addNewHub(@RequestBody Hub newHub) {
         LOGGER.info("About to insert <[{}]>", newHub);
-        try {
-            Hub h = hubMapper.addHub(newHub.getFqHost(), newHub.getMd5(), newHub.getIp());
-            LOGGER.debug("Values returned <[{}]>", h);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", h.getHub_id());
-            jsonObject.put("message", "New hub created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newHub.getHub_id());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                // Get specific error type
-                int error = ((SQLException) cause).getErrorCode();
-                // Link error with state to get accurate error status
-                String state = error + "-" + ((SQLException) cause).getSQLState();
-                if (state.equals("1062-23000")) {
-                    jsonErr.put("message", "ID,MD5 or fqhost already exists");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        Hub h = hubMapper.addHub(newHub.getFqHost(), newHub.getMd5(), newHub.getIp());
+        LOGGER.debug("Values returned <[{}]>", h);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", h.getHub_id());
+        jsonObject.put("message", "New hub created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     // Delete
@@ -251,29 +217,10 @@ public class HubController {
     })
     public ResponseEntity<String> removeHub(@PathVariable("id") int id) {
         LOGGER.info("Deleting Hub <[{}]>", id);
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", id);
-        try {
-            hubMapper.deleteHub(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Hub with id = " + id + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        hubMapper.deleteHub(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Hub with id = " + id + " deleted.");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teragrep/cfe18/handlers/LinkageController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/LinkageController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -116,23 +115,9 @@ public class LinkageController {
             @PathVariable("name") String name,
             @RequestParam(required = false) Integer version
     ) {
-        try {
-            List<Linkage> l = linkageMapper.getLinkageByName(name, version);
-            return new ResponseEntity<>(l, HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                JSONObject jsonErr = new JSONObject();
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist with the given group name");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-                }
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        List<Linkage> l = linkageMapper.getLinkageByName(name, version);
+        return new ResponseEntity<>(l, HttpStatus.OK);
+
     }
 
     // GET ALL Linkages
@@ -192,25 +177,18 @@ public class LinkageController {
     })
     public ResponseEntity<String> newLinkage(@RequestBody Linkage newLinkage) {
         LOGGER.info("About to insert <[{}]>", newLinkage);
-        try {
-            Linkage l = linkageMapper.addLinkage(newLinkage.getHost_group_id(), newLinkage.getCapture_group_id());
-            LOGGER.debug("Values returned <[{}]>", l);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", l.getId());
-            jsonObject
-                    .put(
-                            "message",
-                            "New linkage created for groups = " + l.getCapture_group_name() + " and "
-                                    + l.getHost_group_name()
-                    );
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newLinkage.getId());
-            jsonErr.put("message", ex.getCause().toString());
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        Linkage l = linkageMapper.addLinkage(newLinkage.getHost_group_id(), newLinkage.getCapture_group_id());
+        LOGGER.debug("Values returned <[{}]>", l);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", l.getId());
+        jsonObject
+                .put(
+                        "message",
+                        "New linkage created for groups = " + l.getCapture_group_name() + " and "
+                                + l.getHost_group_name()
+                );
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     // Delete
@@ -244,30 +222,11 @@ public class LinkageController {
     })
     public ResponseEntity<String> removeLinkage(@PathVariable("id") int id) {
         LOGGER.info("Deleting Linkage <[{}]>", id);
-        JSONObject jsonErr = new JSONObject();
-        jsonErr.put("id", id);
-        try {
-            linkageMapper.deleteLinkage(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Linkage with id = " + id + " deleted.");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (Exception ex) {
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                }
-                return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-            }
-            return new ResponseEntity<>("Unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        linkageMapper.deleteLinkage(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Linkage with id = " + id + " deleted.");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
 
     }
 

--- a/src/main/java/com/teragrep/cfe18/handlers/SinkController.java
+++ b/src/main/java/com/teragrep/cfe18/handlers/SinkController.java
@@ -64,7 +64,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.List;
 
 @RestController
@@ -118,37 +117,14 @@ public class SinkController {
     })
     public ResponseEntity<String> create(@RequestBody Sink newSink) {
         LOGGER.info("About to insert <[{}]>", newSink);
-        try {
-            Sink n = sinkMapper
-                    .create(newSink.getProtocol(), newSink.getIpAddress(), newSink.getPort(), newSink.getFlowId());
-            LOGGER.debug("Values returned <[{}]>", n);
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("id", n.getId());
-            jsonObject.put("message", "New sink created");
-            return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", newSink.getId());
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                // 23000 = Constraint exception, Foreign key constract fails
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Flow and protocol combination already exists");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                    // 22001 = Constraint exception, Foreign key constract fails for too long data column
-                }
-                else if (state.equals("22001")) {
-                    jsonErr.put("message", "Port length exceeded");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        Sink n = sinkMapper
+                .create(newSink.getProtocol(), newSink.getIpAddress(), newSink.getPort(), newSink.getFlowId());
+        LOGGER.debug("Values returned <[{}]>", n);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", n.getId());
+        jsonObject.put("message", "New sink created");
+        return new ResponseEntity<>(jsonObject.toString(), HttpStatus.CREATED);
+
     }
 
     @RequestMapping(
@@ -180,27 +156,9 @@ public class SinkController {
             )
     })
     public ResponseEntity<?> get(@PathVariable("id") int id, @RequestParam(required = false) Integer version) {
-        try {
-            Sink s = sinkMapper.get(id, version);
-            return new ResponseEntity<>(s, HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                // 45000 = Custom error, row does not exist
-                if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        Sink s = sinkMapper.get(id, version);
+        return new ResponseEntity<>(s, HttpStatus.OK);
+
     }
 
     @RequestMapping(
@@ -263,34 +221,11 @@ public class SinkController {
     })
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         LOGGER.info("Deleting sink <[{}]>", id);
-        try {
-            sinkMapper.delete(id);
-            JSONObject j = new JSONObject();
-            j.put("id", id);
-            j.put("message", "Sink deleted");
-            return new ResponseEntity<>(j.toString(), HttpStatus.OK);
-        }
-        catch (RuntimeException ex) {
-            LOGGER.error(ex.getMessage());
-            JSONObject jsonErr = new JSONObject();
-            jsonErr.put("id", id);
-            jsonErr.put("message", ex.getCause().getMessage());
-            final Throwable cause = ex.getCause();
-            if (cause instanceof SQLException) {
-                LOGGER.error((cause).getMessage());
-                String state = ((SQLException) cause).getSQLState();
-                // 23000 = Constraint exception, Foreign key constract fails
-                if (state.equals("23000")) {
-                    jsonErr.put("message", "Is in use");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.CONFLICT);
-                    // 45000 = Custom error, row does not exist
-                }
-                else if (state.equals("45000")) {
-                    jsonErr.put("message", "Record does not exist");
-                    return new ResponseEntity<>(jsonErr.toString(), HttpStatus.NOT_FOUND);
-                }
-            }
-            return new ResponseEntity<>(jsonErr.toString(), HttpStatus.BAD_REQUEST);
-        }
+        sinkMapper.delete(id);
+        JSONObject j = new JSONObject();
+        j.put("id", id);
+        j.put("message", "Sink deleted");
+        return new ResponseEntity<>(j.toString(), HttpStatus.OK);
+
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 # Database Config
-spring.datasource.url=jdbc:mariadb://192.168.39.243:30765/cfe_18
-spring.datasource.username=root
-spring.datasource.password=rootsalasanacfe18
-spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.datasource.url=${tests.dbunit.connection.url}/cfe_18
+spring.datasource.username=${tests.dbunit.username}
+spring.datasource.password=${tests.dbunit.password}
+spring.datasource.driver-class-name=${tests.dbunit.driver.class}
 # To show logs for each query
 spring.jpa.show-sql=true
 ## Hibernate settings

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 # Database Config
-spring.datasource.url=${tests.dbunit.connection.url}/cfe_18
-spring.datasource.username=${tests.dbunit.username}
-spring.datasource.password=${tests.dbunit.password}
-spring.datasource.driver-class-name=${tests.dbunit.driver.class}
+spring.datasource.url=jdbc:mariadb://192.168.39.243:30765/cfe_18
+spring.datasource.username=root
+spring.datasource.password=rootsalasanacfe18
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 # To show logs for each query
 spring.jpa.show-sql=true
 ## Hibernate settings

--- a/src/main/resources/db/migration/R__Procedure_Delete_Capture.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Capture.sql
@@ -54,7 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.capture_definition WHERE id = capture_id) = 0) THEN
-        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO =8000;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.capture_type WHERE id = capture_id;
     DELETE FROM cfe_18.capture_definition WHERE id = capture_id;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Capture.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Capture.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.capture_definition WHERE id = capture_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture does not exist') INTO @c;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @c;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO =8000;
     END IF;
     DELETE FROM cfe_18.capture_type WHERE id = capture_id;
     DELETE FROM cfe_18.capture_definition WHERE id = capture_id;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Capture_Group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Capture_Group.sql
@@ -55,8 +55,7 @@ BEGIN
     START TRANSACTION;
 
     IF ((SELECT COUNT(id) FROM cfe_18.capture_def_group WHERE id = capture_group_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_group_id, 'message', 'Capture group does not exist') INTO @cg;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @cg;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     DELETE FROM cfe_18.capture_def_group WHERE id = capture_group_id;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Capture_from_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Capture_from_group.sql
@@ -58,8 +58,7 @@ BEGIN
          FROM cfe_18.capture_def_group_x_capture_def
          WHERE capture_def_id = capture_id
            AND capture_def_group_id = capture_group_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture does not exist OR capture is not linked to group') INTO @c;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @c;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     DELETE

--- a/src/main/resources/db/migration/R__Procedure_Delete_File_Processing_Type.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_File_Processing_Type.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.file_processing_type WHERE p_id = id) = 0) THEN
-        SELECT JSON_OBJECT('id', p_id, 'message', 'File processing type does not exist') INTO @pt;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @pt;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     DELETE FROM cfe_18.file_processing_type WHERE p_id = id;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Flow.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Flow.sql
@@ -53,9 +53,10 @@ BEGIN
             RESIGNAL;
         END;
     START TRANSACTION;
+
+
     IF ((SELECT COUNT(id) FROM cfe_18.flows WHERE id = flow_id) = 0) THEN
-        SELECT JSON_OBJECT('id', flow_id, 'message', 'Flow does not exist') INTO @f;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @f;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 8000;
     END IF;
     DELETE FROM cfe_18.flows WHERE id = flow_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Flow.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Flow.sql
@@ -56,7 +56,7 @@ BEGIN
 
 
     IF ((SELECT COUNT(id) FROM cfe_18.flows WHERE id = flow_id) = 0) THEN
-        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 8000;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.flows WHERE id = flow_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Sink.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Sink.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.capture_sink WHERE id = sink_id) = 0) THEN
-        SELECT JSON_OBJECT('id', sink_id, 'message', 'Capture sink does not exist') INTO @cs;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @cs;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.capture_sink WHERE id = sink_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Delete_Storage.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_Storage.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.storages WHERE id = proc_storage_id) = 0) THEN
-        SELECT JSON_OBJECT('id', proc_storage_id, 'message', 'Storage does not exist') INTO @s;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @s;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.storages WHERE id = proc_storage_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Delete_host_file.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_host_file.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.host WHERE id = proc_host_id) = 0) THEN
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host does not exist') INTO @h;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @h;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.host_type_cfe WHERE host_id = proc_host_id;
     DELETE FROM cfe_18.host WHERE id = proc_host_id;

--- a/src/main/resources/db/migration/R__Procedure_Delete_host_relp.sql
+++ b/src/main/resources/db/migration/R__Procedure_Delete_host_relp.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     IF ((SELECT COUNT(id) FROM cfe_18.host WHERE id = proc_host_id) = 0) THEN
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host does not exist') INTO @h;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @h;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     DELETE FROM cfe_18.host WHERE id = proc_host_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Remove_Capture_Storage.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_Capture_Storage.sql
@@ -57,8 +57,7 @@ BEGIN
         from cfe_18.capture_def_x_flow_targets
         where capture_def_id = proc_capture_id
           and flow_target_id = proc_storage_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Capture storage does not exist') into @cs;
-        signal sqlstate '45000' set message_text = @cs;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete
     from cfe_18.capture_def_x_flow_targets

--- a/src/main/resources/db/migration/R__Procedure_Remove_Flow_Storage.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_Flow_Storage.sql
@@ -55,8 +55,7 @@ BEGIN
     START TRANSACTION;
     select id into @FlowId from cfe_18.flows where name = proc_flow;
     if (select id from cfe_18.flow_targets where flow_id = @FlowId and storage_id = proc_storage_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Flow storage does not exist') into @fs;
-        signal sqlstate '45000' set message_text = @fs;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete from cfe_18.flow_targets where storage_id = proc_storage_id and flow_id = @FlowId;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Remove_G_x_G.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_G_x_G.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.host_groups_x_capture_def_group where id = linkage_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Linkage does not exist') into @l;
-        signal sqlstate '45000' set message_text = @l;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete from cfe_18.host_groups_x_capture_def_group where id = linkage_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Remove_Host.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_Host.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.host where id = proc_host_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Host does not exist') into @h;
-        signal sqlstate '45000' set message_text = @h;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete from cfe_18.host where id = proc_host_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Remove_HostMeta.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_HostMeta.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.host_meta where id = proc_host_meta_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Hostmeta does not exist') into @hm;
-        signal sqlstate '45000' set message_text = @hm;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete from cfe_18.host_meta where id = proc_host_meta_id;
     COMMIT;

--- a/src/main/resources/db/migration/R__Procedure_Remove_Host_Group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_Host_Group.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.host_group where groupName = proc_host_group_name) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Host group does not exist') into @hg;
-        signal sqlstate '45000' set message_text = @hg;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     delete from cfe_18.host_group where groupName = proc_host_group_name;

--- a/src/main/resources/db/migration/R__Procedure_Remove_Hub.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_Hub.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.hubs where id = proc_hub_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Hub does not exist') into @h;
-        signal sqlstate '45000' set message_text = @h;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
 
@@ -77,9 +76,7 @@ BEGIN
         into @hamount
         from cfe_18.host_type_cfe htc2
         where hub_id = proc_hub_id;
-        SELECT JSON_OBJECT('amount', @hamount, 'message', 'Hosts use the given hub')
-        into @ha;
-        signal sqlstate '23000' set message_text = @ha;
+        signal sqlstate '45000' set MYSQL_ERRNO = 50020 ;
     end if;
 
     delete from cfe_18.host_type_cfe where hub_id = proc_hub_id;

--- a/src/main/resources/db/migration/R__Procedure_Remove_cfe_04_transform.sql
+++ b/src/main/resources/db/migration/R__Procedure_Remove_cfe_04_transform.sql
@@ -56,8 +56,7 @@ BEGIN
     if (select id
         from cfe_18.cfe_04_transforms
         where id = transforms_id) is null then
-        SELECT JSON_OBJECT('id', null, 'message', 'Transform record does not exist') into @c4t;
-        signal sqlstate '45000' set message_text = @c4t;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     delete
     from cfe_18.cfe_04_transforms

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Capture_File.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Capture_File.sql
@@ -61,8 +61,7 @@ BEGIN
     end if;
 
     if (select id from capture_definition for system_time as of transaction @time where id = proc_id) is null then
-        SELECT JSON_OBJECT('id', proc_id, 'message', 'Capture does not exist with the given ID') into @cid;
-        signal sqlstate '45000' set message_text = @cid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
 

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Capture_Storages.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Capture_Storages.sql
@@ -61,8 +61,7 @@ BEGIN
     end if;
 
     if ((select count(id) from cfe_18.capture_def_x_flow_targets for system_time as of transaction @time where capture_def_id = capture_id) = 0) then
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture storage does not exist with given ID') into @cs;
-        signal sqlstate '45000' set message_text = @cs;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     else
         select s.storage_name as storage_name, cdxft.flow_target_id as storage_id, cdxft.capture_def_id as capture_id
         from capture_def_x_flow_targets for system_time as of transaction @time cdxft

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Flow_Storages.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Flow_Storages.sql
@@ -59,8 +59,7 @@ BEGIN
              set @time=tx_id;
     end if;
     if (select id from flows for system_time as of transaction @time where name = flow) is null then
-        SELECT JSON_OBJECT('id', NULL, 'message', 'Flow does not exist') into @fs;
-        signal sqlstate '45000' set message_text = @fs;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     else
         select s.storage_name  as target,
                f.name          as flow,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Host.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Host.sql
@@ -59,16 +59,14 @@ BEGIN
              set @time=tx_id;
         end if;
     if (select id from cfe_18.host for system_time as of transaction @time where id = proc_host_id) is null then
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host does not exist with the given ID') into @hid;
-        signal sqlstate '45000' set message_text = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     if (select h.id
         from cfe_18.host for system_time as of transaction @time h
                  inner join hubs for system_time as of transaction @time h3 on h.id = h3.host_id
         where h.id = proc_host_id) is not null then
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host given is hub') into @hub;
-        signal sqlstate '45100' set message_text = @hub;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50060;
     elseif (select id from cfe_18.host for system_time as of transaction @time where id = proc_host_id and host_type = 'CFE') then
 
         select h.id          as host_id,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Host_File.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Host_File.sql
@@ -59,16 +59,14 @@ BEGIN
         SET @time = tx_id;
     END IF;
     IF ((SELECT COUNT(id) FROM cfe_18.host FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = proc_host_id) = 0) THEN
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host does not exist') INTO @hid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     IF ((SELECT COUNT(h.id)
          FROM cfe_18.host FOR SYSTEM_TIME AS OF TRANSACTION @time h
                   INNER JOIN hubs FOR SYSTEM_TIME AS OF TRANSACTION @time h3 ON h.id = h3.host_id
          WHERE h.id = proc_host_id) > 0) THEN
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host is hub') INTO @hub;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hub;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50060;
     ELSE
         SELECT h.id          AS id,
                h.md5         AS host_md5,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Host_Meta.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Host_Meta.sql
@@ -61,9 +61,7 @@ BEGIN
         end if;
     if (select id from host_meta for system_time as of transaction @time where id = proc_host_meta_id) is null
     then
-        SELECT JSON_OBJECT('id', proc_host_meta_id, 'message', 'Host metadata does not exist for the given ID')
-        into @hmd;
-        signal sqlstate '45000' set message_text = @hmd;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     if (((select count(*) from cfe_18.host_meta_x_ip for system_time as of transaction @time where host_meta_id = proc_host_meta_id) and

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Host_Relp.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Host_Relp.sql
@@ -59,8 +59,7 @@ BEGIN
         SET @time = tx_id;
     END IF;
     IF ((SELECT COUNT(id) FROM cfe_18.host FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = proc_host_id) = 0) THEN
-        SELECT JSON_OBJECT('id', proc_host_id, 'message', 'Host does not exist') INTO @hid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT h.id        AS id,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Host_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Host_group.sql
@@ -59,8 +59,7 @@ BEGIN
              set @time=tx_id;
         end if;
     if (select distinct id from cfe_18.host_group for system_time as of transaction @time where groupName = grp_name) is null then
-        SELECT JSON_OBJECT('id', NULL, 'message', 'Host group does not exist.') into @hg;
-        signal sqlstate '45000' set message_text = @hg;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     select h.MD5          as MD5,
            h.id           as host_id,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_Hub.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_Hub.sql
@@ -59,8 +59,7 @@ BEGIN
              set @time=tx_id;
         end if;
     if (select id from cfe_18.hubs for system_time as of transaction @time where id = proc_hub_id) is null then
-        SELECT JSON_OBJECT('id', proc_hub_id, 'message', 'Hub does not exist with given ID') into @hub;
-        signal sqlstate '45000' set message_text = @hub;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
     select hu.id      as hub_id,
            hu.host_id as host_id,

--- a/src/main/resources/db/migration/R__Procedure_Retrieve_g_x_g.sql
+++ b/src/main/resources/db/migration/R__Procedure_Retrieve_g_x_g.sql
@@ -66,8 +66,7 @@ BEGIN
         (select groupName
          from cfe_18.host_group for system_time as of transaction @time
          where groupName = grp_name)) is null then
-        SELECT JSON_OBJECT('id', NULL, 'message', 'group does not exist with the given name') into @gxg;
-        signal sqlstate '45000' set message_text = @gxg;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     -- return resultset accordingly

--- a/src/main/resources/db/migration/R__Procedure_Select_All_Capture_metas.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_All_Capture_metas.sql
@@ -60,8 +60,7 @@ BEGIN
     END IF;
 
     if((select count(*) from cfe_18.capture_meta where capture_id=p_capture_id)=0) THEN
-        SELECT JSON_OBJECT('id', p_capture_id, 'message', 'Capture does not have metadata') INTO @cm;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @cm;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 50000;
     END IF;
 
     IF meta_key IS NULL THEN

--- a/src/main/resources/db/migration/R__Procedure_Select_Capture_Definition.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Capture_Definition.sql
@@ -59,7 +59,7 @@ BEGIN
     END IF;
 
     if ((select count(*) from cfe_18.capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time c where c.id = id) = 0) then
-        signal sqlstate '45000' set MYSQL_ERRNO = 8000;
+        signal sqlstate '45000' set MYSQL_ERRNO = 50000;
     end if;
     SELECT c.id                 AS id,
            t.tag                AS tag,

--- a/src/main/resources/db/migration/R__Procedure_Select_Capture_File.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Capture_File.sql
@@ -62,8 +62,7 @@ BEGIN
 
     IF ((SELECT COUNT(id) FROM capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = capture_id) =
         0) THEN
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture does not exist with the given ID') INTO @cid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @cid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT cd.id                AS id,

--- a/src/main/resources/db/migration/R__Procedure_Select_Capture_Group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Capture_Group.sql
@@ -63,8 +63,7 @@ BEGIN
     IF ((SELECT COUNT(cdg.id)
          FROM capture_def_group FOR SYSTEM_TIME AS OF TRANSACTION @time cdg
          WHERE cdg.id = capture_group_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_group_id, 'message', 'Capture group not found') INTO @gc;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @gc;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT cdg.id                     AS id,

--- a/src/main/resources/db/migration/R__Procedure_Select_Capture_Relp.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Capture_Relp.sql
@@ -62,8 +62,7 @@ BEGIN
 
     IF ((SELECT COUNT(id) FROM capture_definition FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = capture_id) =
         0) THEN
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture does not exist with the given ID') INTO @cid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @cid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
 

--- a/src/main/resources/db/migration/R__Procedure_Select_Capture_meta.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Capture_meta.sql
@@ -65,8 +65,7 @@ BEGIN
          FROM capture_meta FOR SYSTEM_TIME AS OF TRANSACTION @time cm
          WHERE cm.capture_id = capture_id) = 0) THEN
         -- standardized JSON error response
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture meta does not exist with given ID') INTO @nometa;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @nometa;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT cm.capture_id     AS capture_id,

--- a/src/main/resources/db/migration/R__Procedure_Select_Captures_in_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Captures_in_group.sql
@@ -63,8 +63,7 @@ BEGIN
     IF ((SELECT COUNT(cdgxcd.capture_def_group_id)
          FROM capture_def_group_x_capture_def FOR SYSTEM_TIME AS OF TRANSACTION @time cdgxcd
          WHERE cdgxcd.capture_def_group_id = capture_group_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_group_id, 'message', 'Capture group not found') INTO @gc;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @gc;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT cdgxcd.capture_def_id AS capture_definition_id

--- a/src/main/resources/db/migration/R__Procedure_Select_File_Processing_Type.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_File_Processing_Type.sql
@@ -61,8 +61,7 @@ BEGIN
     IF ((SELECT COUNT(id)
          FROM cfe_18.file_processing_type FOR SYSTEM_TIME AS OF TRANSACTION @time fpt
          WHERE fpt.id = id) = 0) THEN
-        SELECT JSON_OBJECT('id', id, 'message', 'File processing type does not exist') INTO @pt;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @pt;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT fpt.id         AS id,

--- a/src/main/resources/db/migration/R__Procedure_Select_Sink.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Sink.sql
@@ -61,8 +61,7 @@ BEGIN
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.capture_sink FOR SYSTEM_TIME AS OF TRANSACTION @time WHERE id = sink_id) = 0) THEN
-        SELECT JSON_OBJECT('id', sink_id, 'message', 'Sink does not exist') INTO @sink;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @sink;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT cs.id          AS id,

--- a/src/main/resources/db/migration/R__Procedure_Select_Storage.sql
+++ b/src/main/resources/db/migration/R__Procedure_Select_Storage.sql
@@ -59,8 +59,7 @@ BEGIN
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.storages WHERE id = storage_id) = 0) THEN
-        SELECT JSON_OBJECT('id', storage_id, 'message', 'Storage does not exist') INTO @pt;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @pt;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     SELECT s.id           AS id,

--- a/src/main/resources/db/migration/R__Procedure_add_cfe_host.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_cfe_host.sql
@@ -61,12 +61,12 @@ BEGIN
     from cfe_18.hubs
              inner join(select id from cfe_18.host where cfe_18.host.fqhost = proc_hub_fq) as hi
     where hubs.host_id = hi.id;
+
     if (select cfe_18.hubs.id
         from cfe_18.hubs
                  inner join(select id from cfe_18.host where cfe_18.host.fqhost = proc_hub_fq) as hi
         where hubs.host_id = hi.id) is null then
-        SELECT JSON_OBJECT('id', @hubs_id, 'message', 'Hub does not exist') into @hub;
-        signal sqlstate '45000' set message_text = @hub;
+        signal sqlstate '45000' set MYSQL_ERRNO =50000;
     else
         if (select id
             from cfe_18.host

--- a/src/main/resources/db/migration/R__Procedure_add_g_x_g.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_g_x_g.sql
@@ -57,22 +57,19 @@ BEGIN
          from cfe_18.capture_def_group
          where id = proc_capture_group_id) !=
         (select distinct host_type from cfe_18.host_group_x_host where host_group_id = proc_host_group_id)) then
-        SELECT JSON_OBJECT('id', NULL, 'message', ' type mismatch between host group and capture group') into @gxg;
-        signal sqlstate '45000' set message_text = @gxg;
+        signal sqlstate '45000' set MYSQL_ERRNO = 50010;
     end if;
     --  Check if host group exists before junction
     IF (select distinct host_group_id
         from cfe_18.host_group_x_host
         where host_group_id = proc_host_group_id) IS NULL THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', ' HOST group does not exist') into @gxgh;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @gxgh;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     --  Check if capture group exists before junction
     IF (select distinct id
         from cfe_18.capture_def_group
         where id = proc_capture_group_id) IS NULL THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', ' CAPTURE group does not exist') into @gxgc;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @gxgc;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
     --  Insert into junction table
     if (select id

--- a/src/main/resources/db/migration/R__Procedure_add_host_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_host_group.sql
@@ -56,8 +56,7 @@ BEGIN
     START TRANSACTION;
 
     if (select id from cfe_18.host where id = proc_host_id) is null then
-        SELECT JSON_OBJECT('id', NULL, 'message', 'host does not exist') into @host;
-        signal sqlstate '45000' set message_text = @host;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     select host_type into @type from cfe_18.host where id = proc_host_id;

--- a/src/main/resources/db/migration/R__Procedure_add_host_meta.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_host_meta.sql
@@ -56,8 +56,7 @@ BEGIN
         END;
     START TRANSACTION;
     if (select id from cfe_18.host where id = p_host_id) is null then
-        SELECT JSON_OBJECT('id', p_host_id, 'message', 'Host does not exist') into @hid;
-        signal sqlstate '45000' set message_text = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     if (select id from cfe_18.os_type where os = p_os) is null then

--- a/src/main/resources/db/migration/R__Procedure_add_relp_host.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_relp_host.sql
@@ -60,8 +60,7 @@ BEGIN
           and fqhost = proc_fqhost
           and host_type != 'RELP') is not null then
         select id into @id from cfe_18.host where MD5 = proc_MD5 and fqhost = proc_fqhost;
-        SELECT JSON_OBJECT('id', @id, 'message', 'Host exists with different host type') into @host;
-        signal sqlstate '45000' set message_text = @host;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50010;
     end if;
     if (select id
         from cfe_18.host

--- a/src/main/resources/db/migration/R__Procedure_add_storage_for_capture.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_storage_for_capture.sql
@@ -55,7 +55,7 @@ BEGIN
     START TRANSACTION;
 
     if (select id from cfe_18.capture_definition where id = capture_id) is null then
-        signal sqlstate '42000' set message_text = 'Capture does not exist with given ID';
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     select flow_id into @FlowId from cfe_18.capture_definition where id = capture_id;

--- a/src/main/resources/db/migration/R__Procedure_add_storage_for_flow.sql
+++ b/src/main/resources/db/migration/R__Procedure_add_storage_for_flow.sql
@@ -56,12 +56,12 @@ BEGIN
     START TRANSACTION;
 
     if (select id from flows where name = flow) is null then
-        signal sqlstate '45000' set message_text = 'flow does not exist';
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     else
         select id into @FlowId from flows where name = flow;
     end if;
     if (select id from storages where id = proc_storage_id) is null then
-        signal sqlstate '45000' set message_text = 'Storage is not valid';
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     select cfe_type into @Storage_type from cfe_18.storages where id = proc_storage_id;

--- a/src/main/resources/db/migration/R__Procedure_create_capture_file.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_capture_file.sql
@@ -62,8 +62,7 @@ BEGIN
     START TRANSACTION;
 
     IF ((SELECT COUNT(id) FROM cfe_18.file_processing_type WHERE id = file_processing_id) = 0) THEN
-        SELECT JSON_OBJECT('id', file_processing_id, 'message', 'Processing type does not exist') INTO @pt;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @pt;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     -- Check if tag_path matches with tag
@@ -74,9 +73,8 @@ BEGIN
         SELECT LEFT(@FinalString, 23) INTO @FinalString;
         SELECT CONCAT(@FinalMd5, '-', @FinalString) INTO @Final;
         IF @Final != meta_tag THEN
-            SELECT JSON_OBJECT('id', @TagId, 'message', 'Tag mismatches with the given tag_path')
-            INTO @tp;
-            SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @tp;
+
+            SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 50030;
         ELSE
             IF ((SELECT COUNT(id) FROM cfe_18.tags WHERE tag = @Final) = 0) THEN
                 INSERT INTO cfe_18.tags(tag)
@@ -140,15 +138,13 @@ BEGIN
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.L7 WHERE app_protocol = protocol) = 0) THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', 'L7 is missing') INTO @L7;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @L7;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     ELSE
         SELECT id INTO @L7Id FROM cfe_18.L7 WHERE app_protocol = protocol;
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.flows WHERE name = flow) = 0) THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', 'Flow is missing') INTO @Flow;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @Flow;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     ELSE
         SELECT id INTO @FlowId FROM cfe_18.flows WHERE name = flow;
     END IF;

--- a/src/main/resources/db/migration/R__Procedure_create_capture_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_capture_group.sql
@@ -54,8 +54,7 @@ BEGIN
         END;
     START TRANSACTION;
     if ((select COUNT(id) from cfe_18.flows f where f.id =p_flow_id)=0) then
-        SELECT JSON_OBJECT('id', p_flow_id, 'message', 'Invalid flow_id') INTO @f;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @f;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     end if;
 
     IF ((SELECT COUNT(id)

--- a/src/main/resources/db/migration/R__Procedure_create_capture_meta.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_capture_meta.sql
@@ -56,9 +56,7 @@ BEGIN
     START TRANSACTION;
     -- check if capture exists for metadata
     IF ((SELECT COUNT(id) FROM cfe_18.capture_definition WHERE id = p_capture_id) = 0) THEN
-        -- standardized JSON error response
-        SELECT JSON_OBJECT('id', p_capture_id, 'message', 'Capture does not exist with given ID') INTO @nocapture;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @nocapture;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     END IF;
 
     -- check key existence

--- a/src/main/resources/db/migration/R__Procedure_create_capture_relp.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_capture_relp.sql
@@ -106,15 +106,13 @@ BEGIN
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.L7 WHERE app_protocol = app_protoc) = 0) THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', 'L7 is missing') INTO @L7;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @L7;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     ELSE
         SELECT id INTO @L7Id FROM cfe_18.L7 WHERE app_protocol = app_protoc;
     END IF;
 
     IF ((SELECT COUNT(id) FROM cfe_18.flows WHERE name = flow) = 0) THEN
-        SELECT JSON_OBJECT('id', NULL, 'message', 'Flow is missing') INTO @Flow;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @Flow;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     ELSE
         SELECT id INTO @FlowId FROM cfe_18.flows WHERE name = flow;
     END IF;

--- a/src/main/resources/db/migration/R__Procedure_create_host_file.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_host_file.sql
@@ -57,18 +57,14 @@ BEGIN
     -- type check
     IF ((SELECT COUNT(id) FROM cfe_18.host WHERE MD5 = proc_MD5 AND fqhost = proc_fqhost AND host_type != 'CFE') >
         0) THEN
-        SELECT JSON_OBJECT('id', (SELECT id FROM cfe_18.host WHERE MD5 = proc_MD5 AND fqhost = proc_fqhost),
-                           'message', 'Host exists with different type')
-        INTO @hid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50010;
     END IF;
 
     IF ((SELECT COUNT(cfe_18.hubs.id)
          FROM cfe_18.hubs
                   INNER JOIN(SELECT id FROM cfe_18.host WHERE cfe_18.host.fqhost = proc_hub_fq) as hi
          WHERE hubs.host_id = hi.id) = 0) THEN
-        SELECT JSON_OBJECT('id', @hubs_id, 'message', 'Hub does not exist') INTO @hub;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hub;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50000;
     ELSE
         IF ((SELECT COUNT(h.id)
              FROM cfe_18.host h

--- a/src/main/resources/db/migration/R__Procedure_create_host_relp.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_host_relp.sql
@@ -57,10 +57,7 @@ BEGIN
     -- type check
     IF ((SELECT COUNT(id) FROM cfe_18.host WHERE MD5 = proc_MD5 AND fqhost = proc_fqhost AND host_type != 'RELP') >
         0) THEN
-        SELECT JSON_OBJECT('id', (SELECT id FROM cfe_18.host WHERE MD5 = proc_MD5 AND fqhost = proc_fqhost),
-                           'message', 'Host exists with different type')
-        INTO @hid;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hid;
+        SIGNAL SQLSTATE '45000' set MYSQL_ERRNO = 50010;
     END IF;
 
     IF ((SELECT COUNT(id)

--- a/src/main/resources/db/migration/R__Procedure_create_link_capture_to_group.sql
+++ b/src/main/resources/db/migration/R__Procedure_create_link_capture_to_group.sql
@@ -60,14 +60,12 @@ BEGIN
 
     -- check if capture_definition ID is valid
     IF ((SELECT COUNT(c.id) FROM cfe_18.capture_definition c WHERE c.id = capture_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_id, 'message', 'Capture does not exist') INTO @capture;
-        SIGNAL SQLSTATE '45001' SET MESSAGE_TEXT = @capture;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO =50000;
     END IF;
 
     -- check if capture_group ID is valid
     IF ((SELECT COUNT(cdg.id) FROM cfe_18.capture_def_group cdg WHERE cdg.id = capture_group_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_group_id, 'message', 'Group does not exist') INTO @group;
-        SIGNAL SQLSTATE '45002' SET MESSAGE_TEXT = @group;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO =50000;
     END IF;
 
     -- check if types match. Select given capture and type while subquerying capture groups type to see if they match.
@@ -76,8 +74,7 @@ BEGIN
          FROM cfe_18.capture_definition c
          WHERE c.capture_type = (SELECT capture_type FROM cfe_18.capture_def_group cdg WHERE cdg.id = capture_group_id)
            AND c.id = capture_id) = 0) THEN
-        SELECT JSON_OBJECT('id', capture_group_id, 'message', 'Type mismatch between capture and group') INTO @mismatch;
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @mismatch;
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO =50010;
     END IF;
 
     -- stored variables are readable than subqueries

--- a/src/main/resources/db/migration/V11__Trigger_duplicate_tag.sql
+++ b/src/main/resources/db/migration/V11__Trigger_duplicate_tag.sql
@@ -66,7 +66,7 @@ begin
                                              ON ttdwcg.capture_def_group_id = hgxldg.capture_group_id) tthwcd
                         ON hgxh.host_group_id = tthwcd.host_group_id;
     if truthvalue = 0 then
-        signal sqlstate '17001' set message_text = 'DUPLICATE HOST ERROR';
+        signal sqlstate '45000' set MYSQL_ERRNO =50040;
     end if;
 end;
 //

--- a/src/test/java/com/teragrep/cfe18/controllerTests/CaptureGroupMembersControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/CaptureGroupMembersControllerTest.java
@@ -297,7 +297,7 @@ public class CaptureGroupMembersControllerTest extends TestSpringBootInformation
         JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Capture does not exist";
+        String expected = "Record does not exist";
 
         // Creating string from Json that was given as a response
         String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
@@ -335,7 +335,7 @@ public class CaptureGroupMembersControllerTest extends TestSpringBootInformation
         JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Group does not exist";
+        String expected = "Record does not exist";
 
         // Creating string from Json that was given as a response
         String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
@@ -455,7 +455,7 @@ public class CaptureGroupMembersControllerTest extends TestSpringBootInformation
         JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Type mismatch between capture group and capture";
+        String expected = "Integration type mismatch";
 
         // Creating string from Json that was given as a response
         String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
@@ -576,7 +576,7 @@ public class CaptureGroupMembersControllerTest extends TestSpringBootInformation
         JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
 
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Tag already exists within given group";
+        String expected = "Duplicate entry";
 
         // Creating string from Json that was given as a response
         String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());

--- a/src/test/java/com/teragrep/cfe18/controllerTests/Cfe04TransformControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/Cfe04TransformControllerTest.java
@@ -191,16 +191,13 @@ public class Cfe04TransformControllerTest extends TestSpringBootInformation {
         // Parsin respponse as JSONObject
         JSONObject responseAsJson = Assertions.assertDoesNotThrow(() -> new JSONObject(responseString));
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "No such cfe_04 id";
-        int expectedId = 0;
+        String expected = "Record does not exist";
 
         // Creating string from Json that was given as a response
         String actual = Assertions.assertDoesNotThrow(() -> responseAsJson.get("message").toString());
-        int actualId = Assertions.assertDoesNotThrow(() -> responseAsJson.getInt("id"));
 
         // Assertions
-        assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
-        assertEquals(expectedId, actualId);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
         assertEquals(expected, actual);
     }
 
@@ -412,7 +409,7 @@ public class Cfe04TransformControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
 
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
         assertEquals(expected, actual);
 
     }

--- a/src/test/java/com/teragrep/cfe18/controllerTests/FileProcessingTypeControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/FileProcessingTypeControllerTest.java
@@ -422,7 +422,7 @@ public class FileProcessingTypeControllerTest extends TestSpringBootInformation 
         assertEquals(HttpStatus.SC_CREATED, captureResponse.getStatusLine().getStatusCode());
 
         assertEquals(expected, actual);
-        assertEquals(HttpStatus.SC_BAD_REQUEST, deleteResponse.getStatusLine().getStatusCode());
+        assertEquals(HttpStatus.SC_CONFLICT, deleteResponse.getStatusLine().getStatusCode());
 
     }
 

--- a/src/test/java/com/teragrep/cfe18/controllerTests/FlowControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/FlowControllerTest.java
@@ -251,7 +251,7 @@ public class FlowControllerTest extends TestSpringBootInformation {
         String expected = "Is in use";
 
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_CONFLICT));
     }
 
     @Test

--- a/src/test/java/com/teragrep/cfe18/controllerTests/GXGControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/GXGControllerTest.java
@@ -419,7 +419,7 @@ public class GXGControllerTest extends TestSpringBootInformation {
         String expected = "Is in use";
 
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_CONFLICT));
     }
 
     @Test
@@ -445,7 +445,7 @@ public class GXGControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
 
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
         assertEquals(expected, actual);
     }
 
@@ -472,7 +472,7 @@ public class GXGControllerTest extends TestSpringBootInformation {
         // Creating expected message as JSON Object from the data that was sent towards endpoint
         String expected = "Record does not exist";
 
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/com/teragrep/cfe18/controllerTests/HubControllerTest.java
+++ b/src/test/java/com/teragrep/cfe18/controllerTests/HubControllerTest.java
@@ -309,7 +309,7 @@ public class HubControllerTest extends TestSpringBootInformation {
         // Creating string from Json that was given as a response
         String actual = responseAsJson.get("message").toString();
         // Creating expected message as JSON Object from the data that was sent towards endpoint
-        String expected = "Is in use";
+        String expected = "Hosts use the hub";
 
         assertEquals(expected, actual);
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
@@ -337,7 +337,7 @@ public class HubControllerTest extends TestSpringBootInformation {
         String expected = "Record does not exist";
 
         assertEquals(expected, actual);
-        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
     }
 
     @Test

--- a/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/ProcedureStorageTest.java
@@ -175,6 +175,6 @@ public class ProcedureStorageTest extends DBUnitbase {
             stmnt.execute();
 
         });
-        Assertions.assertEquals("42000", state.getSQLState());
+        Assertions.assertEquals("45000", state.getSQLState());
     }
 }

--- a/src/test/java/com/teragrep/cfe18/procedureTests/TriggerTagTest.java
+++ b/src/test/java/com/teragrep/cfe18/procedureTests/TriggerTagTest.java
@@ -81,7 +81,7 @@ public class TriggerTagTest extends DBUnitbase {
             stmnt.addBatch("insert into cfe_18.capture_def_group_x_capture_def values(1,3,1,'cfe',1)");
             stmnt.executeBatch();
         });
-        Assertions.assertEquals("17001", state.getSQLState());
+        Assertions.assertEquals("45000", state.getSQLState());
     }
 
     /*


### PR DESCRIPTION
Implemented MariaDBError enum and objects to work with the Enum to make global SQL error handler. Gets rid of controller specific error handling altogether and standardizes error situations. 

Fixes issue https://github.com/teragrep/cfe_18/issues/206 and issue https://github.com/teragrep/cfe_18/issues/177 and issue https://github.com/teragrep/cfe_18/issues/75